### PR TITLE
Target JSON-SCHEMA 2020-12 as the normative dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,11 @@ Normalizing would lead to a consistent unified dataset. For more information see
 ```
 
 ### JSON-SCHEMA
-Current support covers [Draft 4] (https://json-schema.org/specification-links#draft-4).
+OO-LD targets [JSON-SCHEMA 2020-12](#JSONSCHEMA202012) as its normative dialect. An OO-LD schema SHOULD declare `"$schema": "https://json-schema.org/draft/2020-12/schema"` (or an OO-LD dialect meta-schema derived from it).
+
+2020-12 is required, not merely preferred: OO-LD's composition places `$ref` alongside sibling keywords (e.g. a property carrying `type`, `x-oold-range` and `@context`, or `allOf: [{$ref: ...}]` next to `properties`). Keywords adjacent to `$ref` are only evaluated from JSON-SCHEMA 2019-09 onward; in Draft 4 and Draft 7 they are ignored (see [2020-12 Core section 8.2.3.1](https://json-schema.org/draft/2020-12/json-schema-core#section-8.2.3.1)). Keywords such as `const` (used throughout this document) are likewise only available from draft-06 onward.
+
+Migration from the earlier Draft-4-style notation: rename `definitions` to `$defs`, `id` to `$id`, and use the numeric form of `exclusiveMinimum`/`exclusiveMaximum` instead of the boolean form.
 
 #### Multilanguange support
 Keywords `title` and `description` can be extended with additional keywords `title*` and `description*`, which hold and object with lang-keys (de, en, etc.) pointing to the translated strings.
@@ -1152,7 +1156,7 @@ produces a OO-LD schema (JSON-LD context + JSON-SCHEMA with additional annotatio
     '@id': schema:PostalAddress
   Organization:
     '@id': schema:Organization
-$schema: https://json-schema.org/draft/2019-09/schema
+$schema: https://json-schema.org/draft/2020-12/schema
 $id: https://example.org/Person/
 metamodel_version: 1.7.0
 version: null


### PR DESCRIPTION
Implements the dialect retarget from #37 (gap analysis #18, decision 1).

## Change

- Replace the `### JSON-SCHEMA` "Current support covers Draft 4" line with a statement that OO-LD targets JSON-SCHEMA 2020-12 as its normative dialect, including the rationale (composition relies on 2019-09+ `$ref`-with-siblings semantics; `const` is draft-06+) and a Draft-4 to 2020-12 migration note.
- Align the LinkML mapping example to `draft/2020-12/schema` (was `2019-09`).

The rest of the document already references 2020-12 (normative references, intro, section links); this removes the lone Draft-4 inconsistency.

## Note

The composition example uses `x-oold-range` (the prefixed OO-LD keyword per #42 / decision 6). The existing `### Range of properties` section still uses `range` and will be renamed under #20 / #42.

## Acceptance criteria (#37)

- [x] README declares JSON-SCHEMA 2020-12
- [x] Draft-4 to 2020-12 idiom migration list documented
- [ ] All examples validate against the 2020-12 meta-schema (follow-up verification)
