### PR TITLE
Prefix OO-LD keywords with x-oold-, add dialect meta-schema and CI validation

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -1,0 +1,16 @@
+name: Validate OO-LD schemas
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm install
+      - run: npm run validate

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ see also
 -  https://www.w3.org/TR/owl-ref/#VersionInformation
 -  https://github.com/json-schema-org/website/issues/197
 
-The schema version SHOULD be indicated by `x-oold-version`, a prior version MAY be indicated with `oold-prior-version`
+The schema version SHOULD be indicated by `x-oold-version`, a prior version MAY be indicated with `x-oold-prior-version`
 
 ```yaml
 $id: https://example.org/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
@@ -317,8 +317,8 @@ x-oold-uuid: b5203131-7321-46bb-8a11-acb3d1015840
 title: Foo
 x-oold-version: 1.1.0
 x-oold-prior-version: 1.0.0
-backward-compatible-with: https://example.org/my-package/2.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
-incompatible-with: https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
+x-oold-backward-compatible-with: https://example.org/my-package/2.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
+x-oold-incompatible-with: https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
 ```
 Schemas within a package or package repository may use relative URIs (see https://www.rfc-editor.org/rfc/rfc3986#section-5.1), e.g.
 `https://raw.githubusercontent.com/MyOrg/my-package/refs/heads/2.0.0/A.schema.json`
@@ -344,6 +344,27 @@ $schema: https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d10158
 ```
 
 Upgrade-APIs MAY provide automated data migration between schema (package) versions, e.g. `https://example.org/upgrade/my-package/1.0.0...2.0.0`
+
+## Meta-schema and vocabulary
+
+OO-LD adds keywords on top of JSON-SCHEMA 2020-12. All OO-LD-proprietary keywords are prefixed with `x-oold-` so they are valid [JSON-SCHEMA extension keywords](https://json-schema.org/draft/2020-12/json-schema-core#section-6.5) and, at the same time, valid [OpenAPI 3.0 Specification Extensions](https://spec.openapis.org/oas/v3.0.3.html#specification-extensions) (OpenAPI 3.0 rejects unprefixed custom keywords in a Schema Object). The only non-prefixed OO-LD-specific entry is `@context`, which is a JSON-LD keyword and cannot be renamed.
+
+The OO-LD dialect is described by a meta-schema ([`meta/oold-meta-schema.json`](meta/oold-meta-schema.json)). It extends the standard 2020-12 meta-schema and adds the syntax of the `x-oold-*` keywords, so an OO-LD schema can be validated *as* an OO-LD schema. The meta-schema declares its vocabularies via `$vocabulary`: the seven standard 2020-12 vocabularies are re-listed as required (they are not inherited through `$ref`, see [Core section 8.1.2.2](https://json-schema.org/draft/2020-12/json-schema-core#section-8.1.2.2)), and the OO-LD vocabulary is declared **optional** (`false`) so that generic 2020-12 validators still process OO-LD schemas instead of refusing them.
+
+Declaring a vocabulary does not make a validator execute keyword behavior; that is supplied by OO-LD-aware tooling (e.g. the `oold` library). The meta-schema only validates that `x-oold-*` keywords are well-formed and provides a machine-readable `description` for each.
+
+The `x-oold-*` keywords are:
+
+| Keyword | Purpose |
+|---|---|
+| `x-oold-uuid` | Stable UUID identifying the schema across versions and locations |
+| `x-oold-version` / `x-oold-prior-version` | Semantic version of the schema, and its predecessor |
+| `x-oold-backward-compatible-with` / `x-oold-incompatible-with` | URIs of prior versions this schema is / is not compatible with |
+| `x-oold-iri` | Ontology IRI denoting the class described by the schema |
+| `x-oold-range` | Type constraint on an IRI-valued property (IRI, array of IRIs, or an OO-LD subschema) |
+| `x-oold-ref` | Reference to another OO-LD schema, resolved only by OO-LD-aware tools (use instead of `$ref` inside `x-oold-range`) |
+| `x-oold-multilang-title` / `x-oold-multilang-description` | Language maps of translated `title` / `description` |
+| `x-oold-reverse-properties` / `x-oold-reverse-required` / `x-oold-reverse-defaultProperties` | Reverse-property definitions (see [Reverse properties](#reverse-properties)) |
 
 ## Standard extensions
 ### JSON-LD
@@ -430,21 +451,21 @@ OO-LD targets [JSON-SCHEMA 2020-12](#JSONSCHEMA202012) as its normative dialect.
 Migration from the earlier Draft-4-style notation: rename `definitions` to `$defs`, `id` to `$id`, and use the numeric form of `exclusiveMinimum`/`exclusiveMaximum` instead of the boolean form.
 
 #### Multilanguange support
-Keywords `title` and `description` can be extended with additional keywords `title*` and `description*`, which hold and object with lang-keys (de, en, etc.) pointing to the translated strings.
-Mapping of `title*[lang]` must be provided by schema preprocessing.
+Keywords `title` and `description` can be extended with additional keywords `x-oold-multilang-title` and `x-oold-multilang-description`, which hold and object with lang-keys (de, en, etc.) pointing to the translated strings.
+Mapping of `x-oold-multilang-title[lang]` must be provided by schema preprocessing.
 ```json
 {
     "title": "Default Title",
-    "title*": {"en": "Title (en)", "de": "Titel (de)"}
+    "x-oold-multilang-title": {"en": "Title (en)", "de": "Titel (de)"}
 }
 ```
 
 #### Range of properties
-JSON-SCHEMA itself supports linked data only in form of subobject. References to independent external object are just URL-strings without any further restrictions. To express constrains on the type of the object as we know it from OWL and SHACL the keyword `range` is introduced (see also [json-schema-org/json-schema-vocabularies#55](https://github.com/json-schema-org/json-schema-vocabularies/issues/55)). Note: Same as `$ref`, `range` must point to a resolvable resource.
+JSON-SCHEMA itself supports linked data only in form of subobject. References to independent external object are just URL-strings without any further restrictions. To express constrains on the type of the object as we know it from OWL and SHACL the keyword `x-oold-range` is introduced (see also [json-schema-org/json-schema-vocabularies#55](https://github.com/json-schema-org/json-schema-vocabularies/issues/55)). Note: Same as `$ref`, `x-oold-range` must point to a resolvable resource.
 
 ##### Draft v0.1:
 
-`range` is an IRI. While this is concise, there's no way to express unions and intersections of multiple schemas.
+`x-oold-range` is an IRI. While this is concise, there's no way to express unions and intersections of multiple schemas.
 
 ```json
 {
@@ -457,7 +478,7 @@ JSON-SCHEMA itself supports linked data only in form of subobject. References to
   "properties": {
     "works_for": {
       "type": "string",
-      "range": "schema:Organization",
+      "x-oold-range": "schema:Organization",
       "description": "IRI pointing to an instance of schema:Organization",
     }
   }
@@ -466,13 +487,13 @@ JSON-SCHEMA itself supports linked data only in form of subobject. References to
 
 ##### Draft v0.2:
 
-`range` is an OO-LD schema. By using `...Of` keywords, unions (`anyOf` / `oneOf`) and intersections (`allOf`) of multiple schemas can be expressed.
+`x-oold-range` is an OO-LD schema. By using `...Of` keywords, unions (`anyOf` / `oneOf`) and intersections (`allOf`) of multiple schemas can be expressed.
 
 This will allow the following constellations:
 
 ###### Inline type restriction
 ```json
-"range": {
+"x-oold-range": {
   "@context": {
     "schema": "http://schema.org/",
     "type": "@type"
@@ -489,7 +510,7 @@ This will allow the following constellations:
 
 ###### Reference to existing schema
 ```json
-"range": {
+"x-oold-range": {
   "allOf": {
     "$ref": "Organization.schema.json"
   }
@@ -515,7 +536,7 @@ This will allow the following constellations:
     },
     "works_for": {
       "type": "string",
-      "range": {
+      "x-oold-range": {
         "allOf": {
           "$ref": "Organization.schema.json"
         }
@@ -545,7 +566,7 @@ This will allow the following constellations:
 ```
 </details>
 
-On the downside, `range` may build up large schema graphs with circular paths which can raise issues in JSON-SCHEMA bundlers following all `$ref` relations. However, [JSON-SCHEMA]{#JSONSCHEMA202012} recommends standard bundlers not to follow `$ref` within custom keywords in [section 9.4.2](https://json-schema.org/draft/2020-12/json-schema-core#name-references-to-possible-non-). See also https://json-schema.org/blog/posts/bundling-json-schema-compound-documents.
+On the downside, `x-oold-range` may build up large schema graphs with circular paths which can raise issues in JSON-SCHEMA bundlers following all `$ref` relations. However, [JSON-SCHEMA]{#JSONSCHEMA202012} recommends standard bundlers not to follow `$ref` within custom keywords in [section 9.4.2](https://json-schema.org/draft/2020-12/json-schema-core#name-references-to-possible-non-). See also https://json-schema.org/blog/posts/bundling-json-schema-compound-documents.
 
 #### Reverse properties
 There are many cases were relations are summetric, e.g. Organization employees Person <=> Person worksFor Organization.
@@ -592,7 +613,7 @@ Example:
         "type": "string",
         "format": "autocomplete",
         "title": "Person",
-        "range": "Person.schema.json"
+        "x-oold-range": "Person.schema.json"
       }
     }
   }
@@ -623,7 +644,7 @@ Example:
         "type": "string",
         "title": "Organization",
         "format": "autocomplete",
-        "range": "Organization.schema.json"
+        "x-oold-range": "Organization.schema.json"
       }
     }
   }
@@ -653,7 +674,7 @@ In general we want to keep keywords in 'instance' JSON-documents (=> property na
     "name": "schema:name",
     "type": "@type"
   },
-  "iri": "ex:RawData",
+  "x-oold-iri": "ex:RawData",
   "title": "Person",
   "type": "object",
   "properties": {
@@ -682,7 +703,7 @@ class Person(BaseModel):
                 "name": "schema:name",
                 "type": "@type"
             },
-            "iri": "ex:RawData",  # the IRI of the class
+            "x-oold-iri": "ex:RawData",  # the IRI of the class
         }
     )
     type: Optional[str] = "schema:Person"
@@ -1249,7 +1270,7 @@ to get an auto-generated userinterface (based on https://github.com/json-editor/
 ![grafik](https://github.com/user-attachments/assets/a83d885c-b345-4676-b3af-8a9a29ebfed3)
 
 
-Populating `range` in combination with a proper backend allows user to created non-inlined objects on the fly or link (= store the IRI) to existing ones (see https://opensemantic.world / https://demo.open-semantic-lab.org):
+Populating `x-oold-range` in combination with a proper backend allows user to created non-inlined objects on the fly or link (= store the IRI) to existing ones (see https://opensemantic.world / https://demo.open-semantic-lab.org):
 
 ![grafik](https://github.com/user-attachments/assets/2e61fb48-b779-4b2d-88f3-c71098a605b5)
 

--- a/examples/Organization.schema.json
+++ b/examples/Organization.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "Organization.schema.json",
+  "x-oold-uuid": "c6314242-8432-57cc-9b22-bd4e2026951f",
+  "x-oold-version": "1.0.0",
+  "@context": [
+    "Thing.schema.json",
+    { "schema": "http://schema.org/" }
+  ],
+  "title": "Organization",
+  "x-oold-multilang-title": { "en": "Organization", "de": "Organisation" },
+  "allOf": [ { "$ref": "Thing.schema.json" } ],
+  "type": "object"
+}

--- a/examples/Person.schema.json
+++ b/examples/Person.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "Person.schema.json",
+  "x-oold-uuid": "b5203131-7321-46bb-8a11-acb3d1015840",
+  "x-oold-version": "1.0.0",
+  "@context": [
+    "Thing.schema.json",
+    {
+      "schema": "http://schema.org/",
+      "works_for": "schema:worksFor"
+    }
+  ],
+  "title": "Person",
+  "x-oold-multilang-title": { "en": "Person", "de": "Person" },
+  "allOf": [ { "$ref": "Thing.schema.json" } ],
+  "type": "object",
+  "properties": {
+    "works_for": {
+      "type": "string",
+      "format": "autocomplete",
+      "description": "Organization the person works for",
+      "x-oold-range": "Organization.schema.json"
+    }
+  }
+}

--- a/examples/Thing.schema.json
+++ b/examples/Thing.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "Thing.schema.json",
+  "x-oold-uuid": "1b4de2a0-9d3f-4c2e-9a1b-0e7c5f8a2d10",
+  "x-oold-version": "1.0.0",
+  "@context": {
+    "schema": "http://schema.org/",
+    "name": "schema:name"
+  },
+  "title": "Thing",
+  "x-oold-multilang-title": { "en": "Thing", "de": "Ding" },
+  "type": "object",
+  "properties": {
+    "name": { "type": "string", "description": "Name of the thing" }
+  }
+}

--- a/meta/oold-meta-schema.json
+++ b/meta/oold-meta-schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://oo-ld.github.io/schema/meta/oold-meta-schema.json",
+  "$dynamicAnchor": "meta",
+  "title": "OO-LD dialect meta-schema",
+  "$comment": "Provisional $id and OO-LD vocabulary URI - to be finalized when the canonical hosting location is decided. The OO-LD vocabulary is declared optional (false) so that generic JSON-Schema 2020-12 validators still process OO-LD schemas.",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+    "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+    "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+    "https://json-schema.org/draft/2020-12/vocab/content": true,
+    "https://oo-ld.github.io/schema/vocab/oold": false
+  },
+  "allOf": [
+    { "$ref": "https://json-schema.org/draft/2020-12/schema" }
+  ],
+  "properties": {
+    "@context": {
+      "description": "JSON-LD context for instances of this schema. The schema is consumed as a remote JSON-LD context; this entry is ignored by JSON-Schema validators."
+    },
+    "x-oold-uuid": {
+      "description": "Stable UUID identifying this schema across versions and locations.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "x-oold-version": {
+      "description": "Semantic version of this schema.",
+      "type": "string"
+    },
+    "x-oold-prior-version": {
+      "description": "Identifier or version of the immediately preceding schema version.",
+      "type": "string"
+    },
+    "x-oold-backward-compatible-with": {
+      "description": "URI of a prior schema version this schema is backward-compatible with.",
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "x-oold-incompatible-with": {
+      "description": "URI of a prior schema version this schema is NOT compatible with.",
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "x-oold-iri": {
+      "description": "Ontology IRI (or compact IRI) denoting the class described by this schema.",
+      "type": "string"
+    },
+    "x-oold-ref": {
+      "description": "Reference to another OO-LD schema. Use x-oold-ref (not the standard $ref) for references that appear inside OO-LD custom keywords such as x-oold-range: there a plain $ref would be eagerly - and, for cyclic schema graphs, dangerously - dereferenced by generic JSON-Schema bundlers (the behaviour is undefined per Core section 9.4.2). Keep using the standard $ref for ordinary schema composition (allOf, properties, $defs), which bundlers are expected to resolve. x-oold-ref is resolved only by OO-LD-aware tools, lazily and with cycle handling.",
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "x-oold-range": {
+      "description": "Type constraint on the target of an IRI-valued property: an IRI string, an array of IRIs, or an OO-LD subschema (using x-oold-ref for references). See the 'Range of properties' section.",
+      "anyOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" } },
+        {
+          "type": "object",
+          "$comment": "OO-LD subschema form; references inside it use x-oold-ref. The reverse-property keywords (x-oold-reverse-*) are intentionally not validated within a range subschema for now."
+        }
+      ]
+    },
+    "x-oold-multilang-title": {
+      "description": "Language map of translated `title` values keyed by BCP-47 language code.",
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "x-oold-multilang-description": {
+      "description": "Language map of translated `description` values keyed by BCP-47 language code.",
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "x-oold-reverse-properties": {
+      "description": "Properties stored on the related object but editable from this side, mapped via JSON-LD @reverse.",
+      "type": "object"
+    },
+    "x-oold-reverse-required": {
+      "description": "Names of reverse properties that are required.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "x-oold-reverse-defaultProperties": {
+      "description": "Names of reverse properties shown by default in generated user interfaces.",
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "oold-schema",
+  "private": true,
+  "type": "module",
+  "description": "OO-LD schema specification and validation tooling",
+  "scripts": {
+    "validate": "node scripts/validate.mjs"
+  },
+  "devDependencies": {
+    "@apidevtools/json-schema-ref-parser": "^11.0.0",
+    "ajv": "^8.12.0"
+  }
+}

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1,0 +1,42 @@
+// Validates the OO-LD example schemas, offline and with no hardcoded reference list:
+//   1. the meta-schema is valid against JSON-Schema 2020-12 (ajv validates it on compile),
+//   2. each example is a well-formed OO-LD schema (validated against the meta-schema),
+//   3. each example's standard $ref composition resolves. Because the examples use a
+//      relative $id, the base URI is the retrieval location (the file path locally, the
+//      URL once deployed), so the same relative $ref resolves in both places. We resolve
+//      from disk with json-schema-ref-parser.
+// x-oold-ref / x-oold-range and @context references are intentionally NOT auto-resolved;
+// they are handled by OO-LD-aware tooling.
+import Ajv2020 from "ajv/dist/2020.js";
+import $RefParser from "@apidevtools/json-schema-ref-parser";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const meta = JSON.parse(readFileSync(join(root, "meta", "oold-meta-schema.json"), "utf8"));
+const exDir = join(root, "examples");
+const files = readdirSync(exDir).filter((f) => f.endsWith(".schema.json"));
+
+const ajv = new Ajv2020({ strict: false });
+const validateAsOOLD = ajv.compile(meta); // also validates the meta-schema against 2020-12
+
+let failures = 0;
+for (const f of files) {
+  const path = join(exDir, f);
+  const schema = JSON.parse(readFileSync(path, "utf8"));
+  if (!validateAsOOLD(schema)) {
+    failures++;
+    console.error(`INVALID    ${f} (meta-schema): ` + JSON.stringify(validateAsOOLD.errors));
+    continue;
+  }
+  try {
+    await $RefParser.dereference(path);
+    console.log(`OK         ${f}`);
+  } catch (e) {
+    failures++;
+    console.error(`UNRESOLVED ${f}: ${e.message}`);
+  }
+}
+console.log(`\n${files.length - failures}/${files.length} example schemas valid`);
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
Implements decision 6 (prefixing, #42) and decision 4 (meta-schema + optional vocabulary, #41) from the gap analysis (#18), and adds the CI validation job (#23).

## #42 - prefix all OO-LD-proprietary keywords with `x-oold-`

Every OO-LD custom keyword is prefixed, so it is a valid JSON-SCHEMA extension keyword and a valid OpenAPI 3.0 Specification Extension:

- `range` -> `x-oold-range`
- `title*` / `description*` -> `x-oold-multilang-title` / `x-oold-multilang-description`
- `iri` -> `x-oold-iri`
- `backward-compatible-with` -> `x-oold-backward-compatible-with`; `incompatible-with` -> `x-oold-incompatible-with`; prose `oold-prior-version` -> `x-oold-prior-version`
- Already conforming (unchanged): `x-oold-ref`, `x-oold-reverse-*`, `x-oold-uuid`, `x-oold-version`
- Left unchanged: `@context` (JSON-LD keyword), the `name*` multi-mapping (postponed, #12), third-party json-editor keywords (`format`, `defaultProperties`), and the LinkML mapping example's own `range:`.

## #41 - OO-LD dialect meta-schema + optional `$vocabulary`

- New `meta/oold-meta-schema.json`: extends the 2020-12 meta-schema, re-lists the seven standard vocabularies as required (Core 8.1.2.2), declares the OO-LD vocabulary optional (`false`), and gives each `x-oold-*` keyword a syntax constraint and a `description`.
- New README section "Meta-schema and vocabulary".
- `$id` and the OO-LD vocabulary URI are provisional (flagged in the file) pending the hosting decision.

## #23 - CI validation

- New `examples/` (Thing <- Person, Organization). Examples use a relative `$id` so the base URI is the retrieval location: the same relative `$ref` resolves both locally (file path) and once deployed (URL).
- New `scripts/validate.mjs` + `package.json` and workflow `.github/workflows/validate-schemas.yml` running `npm install && npm run validate`, which checks: the meta-schema is valid 2020-12, each example is a well-formed OO-LD schema, and each example's standard `$ref` composition resolves offline.

## Notes

- `x-oold-range`'s subschema form is left permissive and does not yet validate `x-oold-reverse-*` inside it.
- The `x-oold-range` section still uses `$ref` internally; the `$ref` -> `x-oold-ref` redesign is #20.

## Acceptance criteria

#42:
- [x] OO-LD custom keywords prefixed `x-oold-*`
- [ ] `@context` -> REST-API-LD `x-jsonld-*` derivation documented (follow-up)
- [ ] Delivery-tier table added to README (follow-up)

#41:
- [x] OO-LD dialect meta-schema published + example validates against it
- [x] `$vocabulary` declared optional; generic 2020-12 validator still processes OO-LD schemas
- [x] `x-oold-*` keywords covered by the meta-schema syntax
