### PR TITLE
Recommend @version 1.1 in generated JSON-LD contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   - [Schema Instances](#schema-instances)
   - [Standard extensions](#standard-extensions)
     - [JSON-LD](#json-ld)
+      - [Processing mode (@version)](#processing-mode-version)
       - [Multi-Mapping](#multi-mapping)
     - [JSON-SCHEMA](#json-schema)
       - [Multilanguage support](#multilanguage-support)
@@ -367,7 +368,15 @@ The `x-oold-*` keywords are:
 
 ## Standard extensions
 ### JSON-LD
-Current support covers [v1.1] (https://www.w3.org/TR/json-ld/).
+OO-LD targets [JSON-LD 1.1](https://www.w3.org/TR/json-ld11/).
+
+#### Processing mode (`@version`)
+
+OO-LD composition relies on JSON-LD 1.1 features, in particular scoped contexts: a `$ref` within a `type: object` property is reflected as a property-scoped `@context` (see [Composition](#composition)). Such features are unavailable to a processor running in the `json-ld-1.0` processing mode.
+
+Generated OO-LD contexts SHOULD therefore declare `"@version": 1.1` (the JSON number `1.1`, not the string `"1.1"`). Modern processors default to the 1.1 processing mode, so this is a guard rather than a strict requirement: it prevents a JSON-LD 1.0 processor from silently mis-processing a 1.1 document (see [JSON-LD 1.1 section 4.1.1](https://www.w3.org/TR/json-ld11/#json-ld-1-1-processing-mode)).
+
+Because the first encountered `@version` entry determines the processing mode, it is sufficient to declare `"@version": 1.1` once in the base context of a composition (for example a root `Thing` schema). Schemas that reference that base first in their `@context` array inherit the 1.1 processing mode and need not repeat it.
 
 #### Multi-Mapping
 JSON-LD allows only a single keyword-IRI mapping (or more precisely, ignores all but the last mapping). Currently there is no way to express that a property has two ids (e. g. with `"label": {"@id": ["schema:name", "skos:prefLabel"]}`, see also [json-ld/json-ld.org#160](https://github.com/json-ld/json-ld.org/issues/160)). As a workaround, an additional context notation is provided: `<property>*(*)` pointing to additional `@id` mappings to provide at least a documentation for alternative options or custom RDF generation.

--- a/examples/Address.schema.json
+++ b/examples/Address.schema.json
@@ -4,6 +4,7 @@
   "x-oold-uuid": "e8536464-a654-49ee-bd44-df60424b73b1",
   "x-oold-version": "1.0.0",
   "@context": {
+    "@version": 1.1,
     "schema": "http://schema.org/",
     "country": "schema:addressCountry",
     "streetAddress": "schema:streetAddress"

--- a/examples/Thing.schema.json
+++ b/examples/Thing.schema.json
@@ -4,6 +4,7 @@
   "x-oold-uuid": "1b4de2a0-9d3f-4c2e-9a1b-0e7c5f8a2d10",
   "x-oold-version": "1.0.0",
   "@context": {
+    "@version": 1.1,
     "schema": "http://schema.org/",
     "name": "schema:name"
   },


### PR DESCRIPTION
Implements #38 (gap analysis #18, decision 2): recommend `@version: 1.1` in generated OO-LD JSON-LD contexts.

## Changes

- New "Processing mode (`@version`)" subsection in the JSON-LD section. OO-LD composition relies on JSON-LD 1.1 scoped contexts, which a `json-ld-1.0` processor would not apply. Generated contexts **SHOULD** declare `"@version": 1.1` (the JSON number) as a guard - modern processors default to 1.1, so it is recommended, not required (JSON-LD 1.1 section 4.1.1).
- Clarified that, because the first `@version` encountered sets the processing mode, it is sufficient to declare it **once in the base context** of a composition; derived schemas that reference that base inherit the 1.1 mode and need not repeat it.
- Added `"@version": 1.1` to the two root example contexts (`Thing`, `Address`). `Person`/`Organization`/`Researcher` reference a base context first and inherit the mode, demonstrating the rule.
- Updated the "Current support covers v1.1" line and added a TOC entry.

## Acceptance criteria (#38)

- [x] Normative SHOULD in the composition / JSON-LD section
- [x] Generated contexts and examples include `@version: 1.1` (declared in the base context; inherited by derived schemas)
