### PR TITLE
Formalize instance handling (schema reference, asymmetry, @id, type)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,12 @@ A minimal example:
 
 You can explore this in the [interactive playground](https://oo-ld.github.io/playground/)
 
-Please note that **OO-LD schema documents MUST NOT be interpreted as JSON-LD documents** because this would apply `@context` on the schema itself. The motivation behind this is to have a single document so schemas can be aggregated using both the JSON-SCHEMA `$ref` and the JSON-LD remote `@context` pointing the same resource.
+Note the asymmetry between how schemas and instances are consumed:
+
+- An OO-LD **schema** is consumed as a JSON-LD remote **context** (referenced by its URL from an instance's `@context`), never as a JSON-LD document. **OO-LD schema documents MUST NOT be interpreted as JSON-LD documents**, because that would apply the schema's own `@context` to the schema itself and produce incorrect triples.
+- An OO-LD **instance** *is* a valid JSON-LD document and is processed as such.
+
+This asymmetry is what lets a single document serve both as a JSON-SCHEMA `$ref` target and as a JSON-LD remote `@context` for the same resource. Concretely: an instance is processed directly as a JSON-LD document (e.g. `jsonld.toRDF(instance)`), which loads the schema as a remote context via the instance's `@context`; a schema is only ever referenced as that context and MUST NOT itself be expanded as a document (`jsonld.toRDF(schema)` would wrongly apply the schema's own `@context` to it).
 
 ```mermaid
 %%{init: {'theme': 'neutral' } }%%
@@ -250,13 +255,88 @@ _:b1 <ex:petName> "Bruno" .
 </details>
 
 ## Schema Instances
-https://json-schema.org/draft/2020-12/json-schema-core#name-linking-to-a-schema
-https://json-schema.org/draft/2020-12/json-schema-core#name-the-schema-keyword
+
+An OO-LD instance is a JSON document that conforms to an OO-LD schema. It references that schema in two ways, both pointing at the same (preferably versioned) schema URL:
+
+- `@context` - the schema URL, loaded as a JSON-LD remote context. This is what makes the instance a JSON-LD document.
+- `$schema` - the schema URL, identifying the schema the instance is intended to validate against.
 
 ```yaml
-"@context": Person.schema.json
-$schema: Person.schema.json
+"@context": https://example.org/my-package/1.0.0/Person.schema.json
+$schema: https://example.org/my-package/1.0.0/Person.schema.json
 ```
+
+Instances SHOULD use a versioned schema URL so that it is unambiguous which schema version they conform to.
+
+### Referencing the schema with `$schema`
+
+In standard JSON-SCHEMA, `$schema` identifies the dialect (meta-schema), not the schema an instance validates against (see [Core section 8.1.1](https://json-schema.org/draft/2020-12/json-schema-core#section-8.1.1)); JSON-SCHEMA does not define an in-band way for an instance to point at its own schema. OO-LD therefore uses `$schema` on instances as a convention: standard JSON-SCHEMA validators treat it as ordinary data, while editors (VS Code, JetBrains, JSON Schema Store) and CI checks (e.g. [check-json-schema-meta](https://github.com/thiagowfx/check-json-schema-meta)) honor it. Where the instance is served over HTTP, the standards-conformant alternative is the `describedby` link relation (see [Core section 9.5.1.1](https://json-schema.org/draft/2020-12/json-schema-core#section-9.5.1.1)), optionally with the `profile` media-type parameter ([RFC 6906](https://www.rfc-editor.org/rfc/rfc6906)):
+
+```
+Link: <https://example.org/my-package/1.0.0/Person.schema.json>; rel="describedby"
+```
+
+An OO-LD-aware tool determines an instance's schema in the following order:
+
+1. the `$schema` value, if present;
+2. otherwise, the URL given under `@context`, if the referenced document declares itself to be an OO-LD schema;
+3. otherwise, an inline `@type` (see below) - but only when at least one of the type IRIs resolves to an OO-LD schema.
+
+An implementation MAY additionally maintain a registry mapping rdf:type IRIs to OO-LD schemas to resolve case 3, but such a registry MUST NOT be assumed to exist on the consuming side - so exports must be self-sufficient (see below).
+
+Because an instance carries `$schema` and `@context` as ordinary members, an OO-LD schema that closes its objects with `additionalProperties: false` or `unevaluatedProperties: false` MUST permit these two members, or conforming instances would fail validation.
+
+`@context` already provides a JSON-LD-native link to the schema (resolution case 2 above), so `$schema` is kept primarily for compatibility with the widespread editor and CI convention, not as a second authoritative mechanism. JSON-SCHEMA deliberately does not standardize `$schema` on instances, partly over a self-validation concern: a consumer SHOULD NOT blindly trust the schema an instance declares for itself (a crafted instance could point at a permissive schema) and remains responsible for validating against a schema it trusts.
+
+### Identity (`@id`)
+
+An instance that represents an identifiable entity is identified by an `@id` - the IRI of that entity. This is the JSON-LD node identifier, distinct from `$schema` / `@context` (which identify the schema) and from the schema's own `$id` / `x-oold-uuid`. Without an `@id` the entity is an anonymous blank node and cannot be referenced (for example as the target of an `x-oold-range` or `@reverse` relation).
+
+To keep instance keys variable-name-friendly, schemas SHOULD expose `@id` through an aliased `id` property (as with `type` -> `@type`):
+
+```json
+"@context": { "id": "@id" },
+"properties": { "id": { "type": "string", "format": "iri" } }
+```
+
+An implementation MAY use a non-IRI identifier internally, but when it **exports** an identifiable entity (to JSON-LD / RDF) it MUST assign an `@id` (or the aliased `id`). The `@id` SHOULD be resolveable, and it is RECOMMENDED to mint it from an autogenerated UUID - mirroring the schema's `x-oold-uuid` - e.g. `https://example.org/a1b2c3d4-1234-...`.
+
+Embedded value objects that have no independent identity (for example an `Address` embedded in an `Organization`) MAY omit `@id` and remain blank nodes.
+
+### Carrying the semantic type
+
+The type and semantics of an instance are owned by the OO-LD schema it references; an instance is therefore not required to carry an inline type, and a schema version may remap to different ontology terms without rewriting existing data.
+
+A schema declares the rdf:type(s) of its instances with the `x-oold-instance-rdf-type` keyword (always a list of IRIs, e.g. `["schema:Person"]`):
+
+```json
+{ "x-oold-instance-rdf-type": ["schema:Person"] }
+```
+
+These types live in the schema, not in the instance data, so a JSON-LD-only processor - which sees only the instance and its `@context` - cannot derive them. Therefore, when OO-LD tooling **exports** an instance (to JSON-LD / RDF), it MUST materialize the declared rdf:type(s) as an `@type` on the instance, so that the type reaches RDF without access to the schema or to a type registry.
+
+Alternatively, an instance MAY carry the type inline as a `type` property (self-describing data). The schema maps the `type` term to the JSON-LD keyword `@type` (with `@type: @id` coercion) and gives it a `default`; the value MAY be a single IRI or a list of IRIs, and this property named `type` is distinct from the JSON-SCHEMA `type` keyword:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "type": { "@id": "@type", "@type": "@id" }
+  },
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": ["schema:Person"]
+    }
+  }
+}
+```
+
+A `default` is used here rather than `const`: `const` would also fix the type, but it would prevent a subclass from overriding or extending it (for example a subclass adding `schema:Researcher`). With `default` a subclass can redefine the property.
+
+If an inline `type` is present it MUST be consistent with the schema's `x-oold-instance-rdf-type`. Note that `@type` alone lets a consumer locate the schema (case 3 above) only when one of the type IRIs resolves to an OO-LD schema.
 ## Identification
 
 OO-LD schemas MUST have a `$id` (see https://json-schema.org/draft/2020-12/json-schema-core#section-8.2.1) which works as a global and unique identifier of the schema. The value of `$id` MAY be a absolute URI (details below). The schema SHOULD be resolveable via this URI. The schema SHOULD have a annotation `x-oold-uuid` with an UUID value.
@@ -361,6 +441,7 @@ The `x-oold-*` keywords are:
 | `x-oold-version` / `x-oold-prior-version` | Semantic version of the schema, and its predecessor |
 | `x-oold-backward-compatible-with` / `x-oold-incompatible-with` | URIs of prior versions this schema is / is not compatible with |
 | `x-oold-iri` | Ontology IRI denoting the class described by the schema |
+| `x-oold-instance-rdf-type` | rdf:type(s) instances carry, as a list of IRIs; materialized as `@type` on export |
 | `x-oold-range` | Type constraint on an IRI-valued property (IRI, array of IRIs, or an OO-LD subschema) |
 | `x-oold-ref` | Reference to another OO-LD schema, resolved only by OO-LD-aware tools (use instead of `$ref` inside `x-oold-range`) |
 | `x-oold-multilang-title` / `x-oold-multilang-description` | Translations of `title` / `description` keyed by BCP-47 language tag |

--- a/examples/Address.schema.json
+++ b/examples/Address.schema.json
@@ -3,6 +3,7 @@
   "$id": "Address.schema.json",
   "x-oold-uuid": "e8536464-a654-49ee-bd44-df60424b73b1",
   "x-oold-version": "1.0.0",
+  "x-oold-instance-rdf-type": ["schema:PostalAddress"],
   "@context": {
     "@version": 1.1,
     "schema": "http://schema.org/",

--- a/examples/Organization.schema.json
+++ b/examples/Organization.schema.json
@@ -3,6 +3,7 @@
   "$id": "Organization.schema.json",
   "x-oold-uuid": "c6314242-8432-57cc-9b22-bd4e2026951f",
   "x-oold-version": "1.0.0",
+  "x-oold-instance-rdf-type": ["schema:Organization"],
   "@context": [
     "Thing.schema.json",
     {

--- a/examples/Person.schema.json
+++ b/examples/Person.schema.json
@@ -3,6 +3,7 @@
   "$id": "Person.schema.json",
   "x-oold-uuid": "b5203131-7321-46bb-8a11-acb3d1015840",
   "x-oold-version": "1.0.0",
+  "x-oold-instance-rdf-type": ["schema:Person"],
   "@context": [
     "Thing.schema.json",
     {

--- a/examples/Researcher.schema.json
+++ b/examples/Researcher.schema.json
@@ -3,6 +3,7 @@
   "$id": "Researcher.schema.json",
   "x-oold-uuid": "d7425353-9543-48dd-ac33-ce5f3137a62a",
   "x-oold-version": "1.0.0",
+  "x-oold-instance-rdf-type": ["schema:Person"],
   "@context": [
     "Person.schema.json",
     {

--- a/examples/Thing.schema.json
+++ b/examples/Thing.schema.json
@@ -3,8 +3,10 @@
   "$id": "Thing.schema.json",
   "x-oold-uuid": "1b4de2a0-9d3f-4c2e-9a1b-0e7c5f8a2d10",
   "x-oold-version": "1.0.0",
+  "x-oold-instance-rdf-type": ["schema:Thing"],
   "@context": {
     "@version": 1.1,
+    "id": "@id",
     "schema": "http://schema.org/",
     "name": "schema:name"
   },
@@ -12,6 +14,7 @@
   "x-oold-multilang-title": { "en": "Thing", "de": "Ding" },
   "type": "object",
   "properties": {
+    "id": { "type": "string", "format": "iri", "description": "IRI of the entity" },
     "name": { "type": "string", "description": "Name of the thing" }
   }
 }

--- a/meta/oold-meta-schema.json
+++ b/meta/oold-meta-schema.json
@@ -48,6 +48,11 @@
       "description": "Ontology IRI (or compact IRI) denoting the class described by this schema.",
       "type": "string"
     },
+    "x-oold-instance-rdf-type": {
+      "description": "The rdf:type(s) carried by instances of this schema, as a list of IRIs (e.g. [\"schema:Person\"]). OO-LD tooling materializes these as @type when exporting an instance to JSON-LD / RDF.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
     "x-oold-ref": {
       "description": "Reference to another OO-LD schema. Use x-oold-ref (not the standard $ref) for references that appear inside OO-LD custom keywords such as x-oold-range: there a plain $ref would be eagerly - and, for cyclic schema graphs, dangerously - dereferenced by generic JSON-Schema bundlers (the behaviour is undefined per Core section 9.4.2). Keep using the standard $ref for ordinary schema composition (allOf, properties, $defs), which bundlers are expected to resolve. x-oold-ref is resolved only by OO-LD-aware tools, lazily and with cycle handling.",
       "type": "string",


### PR DESCRIPTION
Implements #34, #35 and #36 (gap analysis #18) by formalizing how OO-LD instances work. The bare "Schema Instances" section is rewritten into a full one.

## #35 - schema/instance asymmetry
Stated prominently in Basic Concepts: a **schema** is consumed as a JSON-LD remote **context** (never as a JSON-LD document), while an **instance** *is* a JSON-LD document, with a concrete example of the correct call for each (`jsonld.toRDF(instance)` vs never on the schema).

## #34 - how an instance references its schema
- Instance references its schema with both `@context` and `$schema` at the same versioned URL.
- Documented (incorporating @LukasOro's research) that instance `$schema` is an OO-LD convention: standard validators treat it as data; editors/CI honor it; `describedby` + the `profile` parameter (RFC 6906) is the HTTP alternative; `@context` already provides a JSON-LD-native link, so `$schema` is kept mainly for tooling compatibility; and the self-validation concern (a consumer must not blindly trust an instance's self-declared schema).
- Schema-resolution order: `$schema` -> `@context` URL (if an OO-LD schema) -> inline `@type` (only when a type IRI resolves to an OO-LD schema). A type->schema registry MAY exist but must not be assumed on export.
- Caveat: `additionalProperties:false`/`unevaluatedProperties:false` schemas MUST permit `$schema` and `@context`.

## #36 - carrying the semantic type
- New keyword **`x-oold-instance-rdf-type`** (a list of IRIs): the schema declares the rdf:type(s) of its instances; OO-LD tooling MUST materialize them as `@type` on **export** (a JSON-LD-only consumer cannot otherwise derive them).
- Or carry the type inline via a `type` property aliased to `@type` with a `default` (not `const`, which would block subclass override); the value MAY be a single IRI or a list. This reconciles the minimal (no type), code-gen (inline `type`) and range examples.

## `@id` on instances (folded in)
- New "Identity (`@id`)" subsection: an identifiable entity is identified by an `@id` (distinct from the schema's `$schema`/`@context`/`$id`/`x-oold-uuid`), exposed via an aliased `id` property. Implementations MAY use a non-IRI id internally but MUST assign an `@id` on export; it SHOULD be resolveable, RECOMMENDED minted from an autogenerated UUID. Embedded value objects MAY omit `@id`.

## Examples + meta-schema
- `x-oold-instance-rdf-type` added to the meta-schema and all example schemas; `Thing` demonstrates the aliased `id` property (inherited by subclasses; the embedded `Address` value object omits `@id`). All 5 examples pass CI.

Notes: `x-oold-instance-rdf-type` is newly introduced as the #36 resolution; `x-oold-iri` (schema class IRI) is left unchanged.
