### PR TITLE
Formalize remote @context composition rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
       - [Interoperability](#interoperability)
   - [Basic Concepts](#basic-concepts)
   - [Composition](#composition)
+    - [Merging remote contexts](#merging-remote-contexts)
   - [Schema Instances](#schema-instances)
   - [Standard extensions](#standard-extensions)
     - [JSON-LD](#json-ld)
@@ -159,8 +160,8 @@ You can read how this is implemented in OpenSemanticWorld/Lab in the [introducti
 
 ## Composition
 
-It MUST NOT be require to further process an OO-LD Schema document in order to interpret it as JSON-LD context. This implies that all occurrences of `$ref` in the schema are reflected in the JSON-LD context. `$ref` within properties of `type: object` MUST be listed as scoped JSON-LD context. `$ref` within all other property types and at the root level of the OO-LD schema MUST be listed at the root level of the JSON-LD context. In case of multiple `$ref` within `allOf` it lies within the responsibility of the importing OO-LD schema to ensure correctness of the merged remote JSON-LD context. 
-This SHOULD NOT be applied to `oneOf` and `anyOf` since conflicts are more likely.
+It MUST NOT be require to further process an OO-LD Schema document in order to interpret it as JSON-LD context. This implies that all occurrences of `$ref` in the schema are reflected in the JSON-LD context. `$ref` within properties of `type: object` MUST be listed as scoped JSON-LD context. `$ref` within all other property types and at the root level of the OO-LD schema MUST be listed at the root level of the JSON-LD context. In case of multiple `$ref` within `allOf` the corresponding remote contexts are merged into an array-valued `@context` (see [Merging remote contexts](#merging-remote-contexts)). 
+For `oneOf` / `anyOf` this requires care to avoid conflicts (see [Merging remote contexts](#merging-remote-contexts)).
 At any time the importing OO-LD schema can define its own or override the imported JSON-LD context.
 
 ```yaml
@@ -253,6 +254,45 @@ _:b0 <schema:name> "Max" .
 _:b1 <ex:petName> "Bruno" .
 ```
 </details>
+
+### Merging remote contexts
+
+**Multiple `$ref` (e.g. in `allOf`)** each correspond to a remote context. By the reflection rule above, the schema's own `@context` MUST list those remote contexts as an **array**, in the same order as the `allOf` members, so the schema stays usable as a context without further processing. A JSON-LD processor then resolves that array in order, later entries overriding earlier ones - "Duplicate context terms are overridden using a most-recently-defined-wins mechanism" ([JSON-LD 1.1, 4.1.5](https://www.w3.org/TR/json-ld11/#advanced-context-usage)). The schema MAY append its own context object as the last array entry to override an inherited term. The single-context `@import` keyword is an alternative only when exactly one remote context is wrapped and locally modified (it cannot contain a nested `@import`), so the array form is used for the multi-`$ref` case.
+
+**`oneOf` / `anyOf`.** The remote contexts of `oneOf` / `anyOf` branches MAY also be reflected into the `@context`, but they MUST NOT conflict at the root - they MUST NOT map the same keyword to different IRIs there. A JSON-LD processor merges all listed contexts (most-recently-wins) and has no notion of which branch a given instance matched, so a root-level conflict would be decided by context order rather than by the branch the data conforms to.
+
+Where branches genuinely need different mappings for the same keyword, do not place them at the root; scope them so each mapping applies only where its branch applies, using JSON-LD scoped contexts:
+
+- **Type-scoped contexts** when the branches are distinguished by `@type`. The scoped `@context` is attached to the term used as the type value and is activated only for nodes carrying that `@type`:
+
+  ```json
+  "@context": {
+    "Sensor": { "@id": "ex:Sensor", "@context": { "reading": "ex:temperature" } },
+    "Gauge":  { "@id": "ex:Gauge",  "@context": { "reading": "ex:pressure" } }
+  }
+  ```
+
+  Here `{ "@type": "Sensor", "reading": 21 }` maps `reading` to `ex:temperature`, while `{ "@type": "Gauge", "reading": 3 }` maps the same keyword to `ex:pressure`.
+
+- **Property-scoped contexts** when the conflicting keyword appears under different parent properties. The mapping is attached to the parent property's term (its `@context`) and applies only within that property's value, so the same keyword can resolve differently under different parents.
+
+**Propagation (`@propagate`).** A `$ref` inside a `type: object` property is reflected as a property-scoped context, which by default propagates into the whole subtree rooted at that property ("By default ... contexts propagate across node objects, other than for type-scoped contexts, which default to false"). Where a referenced context should apply only to the immediate node, the schema MUST set `"@propagate": false` on that scoped context. Contexts combined in a single array MUST share the same `@propagate` value.
+
+**Protected terms (`@protected`).** A schema MAY mark terms `@protected` to prevent later contexts from silently redefining them. When contexts are combined via `allOf`, redefining a protected term to a different IRI is an error unless the new definition is identical; property-scoped contexts are exempt and may override protected terms within their subtree. Relying on `@protected` therefore constrains which schemas a schema can be combined with.
+
+**Independent references and base URIs.** A JSON-SCHEMA `$ref` and a JSON-LD `@context` entry are independent references: they MAY point to the same document (the typical OO-LD case, where one document is both a schema and a context) or to different documents - for example a plain JSON-SCHEMA referenced via `$ref` together with a separate remote `@context` that supplies the semantics. Relative references resolve against the schema's `$id` (the JSON-SCHEMA base URI) and, on the JSON-LD side, against `@base` / the retrieval URL; these base URIs SHOULD be aligned so a relative reference resolves to the same absolute URL under both. `$id` MUST NOT contain a non-empty fragment ([JSON-SCHEMA Core 8.2.1](https://json-schema.org/draft/2020-12/json-schema-core#section-8.2.1)).
+
+### Merging remote contexts
+
+**Multiple `$ref` (e.g. in `allOf`)** each correspond to a remote context. By the reflection rule above, the schema's own `@context` MUST list those remote contexts as an **array**, in the same order as the `allOf` members, so the schema stays usable as a context without further processing. A JSON-LD processor then resolves that array in order, later entries overriding earlier ones - "Duplicate context terms are overridden using a most-recently-defined-wins mechanism" ([JSON-LD 1.1, 4.1.5](https://www.w3.org/TR/json-ld11/#advanced-context-usage)). The schema MAY append its own context object as the last array entry to override an inherited term. The single-context `@import` keyword is an alternative only when exactly one remote context is wrapped and locally modified (it cannot contain a nested `@import`), so the array form is used for the multi-`$ref` case.
+
+**`oneOf` / `anyOf`.** The remote contexts of `oneOf` / `anyOf` branches MAY also be reflected into the `@context`, but they MUST NOT conflict - they MUST NOT map the same keyword to different IRIs. A JSON-LD processor merges all listed contexts (most-recently-wins) and has no notion of which branch a given instance matched, so a conflicting mapping would be decided by context order rather than by the branch the data conforms to. Where branches genuinely need different mappings for the same keyword, scope them with property-scoped or type-scoped contexts so each mapping applies only within its property or `@type`, instead of at the root.
+
+**Propagation (`@propagate`).** A `$ref` inside a `type: object` property is reflected as a property-scoped context, which by default propagates into the whole subtree rooted at that property ("By default ... contexts propagate across node objects, other than for type-scoped contexts, which default to false"). Where a referenced context should apply only to the immediate node, the schema MUST set `"@propagate": false` on that scoped context. Contexts combined in a single array MUST share the same `@propagate` value.
+
+**Protected terms (`@protected`).** A schema MAY mark terms `@protected` to prevent later contexts from silently redefining them. When contexts are combined via `allOf`, redefining a protected term to a different IRI is an error unless the new definition is identical; property-scoped contexts are exempt and may override protected terms within their subtree. Relying on `@protected` therefore constrains which schemas a schema can be combined with.
+
+**Independent references and base URIs.** A JSON-SCHEMA `$ref` and a JSON-LD `@context` entry are independent references: they MAY point to the same document (the typical OO-LD case, where one document is both a schema and a context) or to different documents - for example a plain JSON-SCHEMA referenced via `$ref` together with a separate remote `@context` that supplies the semantics. Relative references resolve against the schema's `$id` (the JSON-SCHEMA base URI) and, on the JSON-LD side, against `@base` / the retrieval URL; these base URIs SHOULD be aligned so a relative reference resolves to the same absolute URL under both. `$id` MUST NOT contain a non-empty fragment ([JSON-SCHEMA Core 8.2.1](https://json-schema.org/draft/2020-12/json-schema-core#section-8.2.1)).
 
 ## Schema Instances
 


### PR DESCRIPTION
Implements #22 (gap analysis #18, finding B4 + C2): formalize how `$ref` and remote `@context` compose. New "Merging remote contexts" subsection in Composition.

- **Multiple `$ref` (allOf):** the schema's own `@context` lists the remote contexts as an **array** in `allOf` order (per the reflection rule, so the schema stays usable as a context without further processing); a JSON-LD processor resolves the array most-recently-wins. `@import` noted as the single-context alternative (no nested import).
- **`oneOf` / `anyOf`:** their contexts MAY be reflected too, but MUST NOT map the same keyword to different IRIs at the root (the processor merges all contexts, most-recently-wins, with no notion of the matched branch). Genuine per-branch differences are resolved with **type-scoped** contexts (keyed on `@type`, with a worked `Sensor`/`Gauge` example) or **property-scoped** contexts.
- **`@propagate`:** a `$ref` in a `type: object` property becomes a property-scoped context that propagates into the subtree by default; set `@propagate: false` to limit it; contexts in one array MUST share the same `@propagate`.
- **`@protected`:** redefining a protected term to a different IRI errors unless identical; property-scoped contexts are exempt.
- **Independent references + base URIs:** `$ref` (JSON-SCHEMA) and `@context` (JSON-LD) are independent - they MAY point to the same document (the OO-LD case) or to different ones (e.g. a plain JSON-SCHEMA `$ref` plus a separate remote context). Base URIs (`$id` vs `@base`) SHOULD align for relative refs; `$id` MUST NOT contain a non-empty fragment (Core 8.2.1).

Also softened the intro's `oneOf`/`anyOf` line to point at the new subsection. No example changes; 5/5 pass CI.
