### PR TITLE
UI annotation extensions: x-oold-ui-* vocabulary and UI meta-schema

### DIFF
--- a/docs/guide/extensions.md
+++ b/docs/guide/extensions.md
@@ -13,6 +13,6 @@ On top of plain JSON Schema and JSON-LD, OO-LD defines a small set of extensions
 - **Multilanguage** - `x-oold-multilang-title` / `x-oold-multilang-description` localize a schema's own labels; instance *values* are localized with standard JSON-LD language maps.
 - **Range (`x-oold-range`)** - constrains the type of a referenced object (an IRI, a union of IRIs, or an inline subschema); references inside it use `x-oold-ref`, not `$ref`.
 - **Reverse properties** (`x-oold-reverse-*`) - edit a symmetric relation from both sides, mapped with JSON-LD `@reverse`.
-- **UI Generation** - keywords from [JSON Editor](https://github.com/json-editor/json-editor) may drive automatic form generation.
+- **UI Generation** (`x-oold-ui-*`) - a portable vocabulary of form/view hints (widget, order, grouping, visibility, enum labels), with vendor pass-through (`x-jedison-*`) and delivery inline or via an overlay.
 
 For the normative rules and worked examples of every keyword above, see [Standard Extensions](../spec/#extensions) in the specification.

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -540,7 +540,7 @@ intersections (<code>allOf</code>) and inline constraints can be combined to des
 }
 </code></pre></aside>
 <p>A range subschema <em class="rfc2119">MAY</em> also carry additional annotations (e.g. <code>title</code>, <code>description</code> or further <code>x-oold-*</code> keywords) to support tooling - for example a human-readable label for an autocomplete dropdown, or hints used when generating a SHACL shape.</p><section id="why-x-oold-ref"><h5>Why <code>x-oold-ref</code> and not <code>$ref</code></h5><p><code>x-oold-range</code> is a custom keyword, so a <code>$ref</code> placed inside it is undefined behavior for generic JSON Schema tooling ([[JSONSCHEMA]] §9.4.2). In practice the behavior is not merely undefined but inconsistent: generic reference resolvers eagerly inline such a <code>$ref</code>, and because <code>x-oold-range</code> targets can form a cyclic graph of schemas this can pull in an unbounded graph, while schema-aware bundlers instead drop it.</p>
-<p><code>x-oold-ref</code> avoids this. Generic tools only follow the standard <code>$ref</code> keyword, so they leave <code>x-oold-ref</code> untouched; OO-LD-aware tools resolve it deliberately and lazily, with cycle detection. The standard <code>$ref</code> continues to be used for ordinary schema composition (<code>allOf</code>, <code>properties</code>, <code>$defs</code>), which bundlers are expected to resolve. Because the only difference is the keyword name, the mapping is reversible: an OO-LD-aware tool can mechanically replace <code>x-oold-ref</code> with <code>$ref</code> to obtain a plain, fully-resolvable JSON Schema - the explicit opt-in to resolving the (possibly cyclic) graph.</p></section></section><section id="reverse-properties"><h4>Reverse properties</h4><p>Many relations are symmetric (e.g. Organization employs Person ⇔ Person works for Organization) and users want to edit them from both sides, without storing the information twice. The keywords <code>x-oold-reverse-properties</code>, <code>x-oold-reverse-default-properties</code> and <code>x-oold-reverse-required</code> declare such a [=reverse property=], mapped with JSON-LD <code>@reverse</code> in the <code>@context</code>. To make <code>employees</code> the reverse of <code>organization</code>:</p>
+<p><code>x-oold-ref</code> avoids this. Generic tools only follow the standard <code>$ref</code> keyword, so they leave <code>x-oold-ref</code> untouched; OO-LD-aware tools resolve it deliberately and lazily, with cycle detection. The standard <code>$ref</code> continues to be used for ordinary schema composition (<code>allOf</code>, <code>properties</code>, <code>$defs</code>), which bundlers are expected to resolve. Because the only difference is the keyword name, the mapping is reversible: an OO-LD-aware tool can mechanically replace <code>x-oold-ref</code> with <code>$ref</code> to obtain a plain, fully-resolvable JSON Schema - the explicit opt-in to resolving the (possibly cyclic) graph.</p></section></section><section id="reverse-properties"><h4>Reverse properties</h4><p>Many relations are symmetric (e.g. Organization employs Person ⇔ Person works for Organization) and users want to edit them from both sides, without storing the information twice. The keywords <code>x-oold-reverse-properties</code> and <code>x-oold-reverse-required</code> declare such a [=reverse property=], mapped with JSON-LD <code>@reverse</code> in the <code>@context</code>. (The earlier <code>x-oold-reverse-default-properties</code> array is deprecated: mark a reverse property shown by default with <code>x-oold-ui-default-property</code> on the property itself - see <a href="#ui-generation"></a> - which, unlike the merged array, is overridable under composition.) To make <code>employees</code> the reverse of <code>organization</code>:</p>
 <ul>
 <li>define <code>employees</code> in <code>x-oold-reverse-properties</code> of <code>Organization</code>;</li>
 <li>define <code>organization</code> in the <code>properties</code> of <code>Person</code>;</li>
@@ -556,11 +556,11 @@ intersections (<code>allOf</code>) and inline constraints can be combined to des
   &quot;type&quot;: &quot;object&quot;,
   &quot;required&quot;: [&quot;type&quot;],
   &quot;x-oold-reverse-required&quot;: [],
-  &quot;x-oold-reverse-default-properties&quot;: [&quot;employees&quot;],
   &quot;x-oold-reverse-properties&quot;: {
     &quot;employees&quot;: {
       &quot;type&quot;: &quot;array&quot;,
       &quot;title&quot;: &quot;Employees&quot;,
+      &quot;x-oold-ui-default-property&quot;: true,
       &quot;items&quot;: {
         &quot;type&quot;: &quot;string&quot;,
         &quot;format&quot;: &quot;autocomplete&quot;,
@@ -592,7 +592,161 @@ intersections (<code>allOf</code>) and inline constraints can be combined to des
   }
 }
 </code></pre></aside>
-<p>An OO-LD-aware implementation uses this to read and modify properties that are actually stored in another object: loading an <code>Organization</code> editor prepopulates <code>employees</code> by querying which persons work for it; storing the <code>Organization</code> writes it into each referenced person's <code>organization</code> field; and removing a person from <code>employees</code> removes the organization from theirs.</p></section><section id="ui-generation" class="informative"><h4>UI Generation</h4><p>Additional keywords defined by <a href="https://github.com/json-editor/json-editor">JSON Editor</a> (see its <a href="https://github.com/json-editor/json-editor#readme">basic features</a> and <a href="https://github.com/json-editor/json-editor/blob/master/README_ADDON.md">add-on details</a>) MAY be used to drive automatic user-interface (form) generation.</p></section></section></section>
+<p>An OO-LD-aware implementation uses this to read and modify properties that are actually stored in another object: loading an <code>Organization</code> editor prepopulates <code>employees</code> by querying which persons work for it; storing the <code>Organization</code> writes it into each referenced person's <code>organization</code> field; and removing a person from <code>employees</code> removes the organization from theirs.</p></section><section id="ui-generation" class="informative"><h4>UI Generation</h4><p>OO-LD schemas double as the source for auto-generated forms and views. UI intent is carried in two layers:</p>
+<ul>
+<li>Portable, renderer-agnostic keywords in the <code>x-oold-ui-*</code> vocabulary, defined here. Any form generator can honour them.</li>
+<li>Renderer-specific keywords passed through under a vendor prefix - <code>x-jedison-*</code> for <a href="https://github.com/germanbisurgi/jedison">jedison</a>, the successor of <a href="https://github.com/json-editor/json-editor">json-editor</a> - for options that do not generalize.</li>
+</ul>
+<p>Every keyword keeps the <code>x-</code> prefix, so it is a valid JSON Schema extension keyword and a valid OpenAPI 3.0 specification extension, and generic 2020-12 validators ignore it. The <code>x-oold-ui-*</code> keywords form their own optional dialect, described by the <a href="../meta/oold-ui-meta-schema.json">OO-LD UI meta-schema</a>; the core meta-schema includes those definitions so an OO-LD schema carrying UI annotations validates in one pass.</p><section id="ui-vocabulary"><h5>The <code>x-oold-ui-*</code> vocabulary</h5><p>All keywords apply to the (sub)schema of a single property.</p>
+<table class="def">
+<thead>
+<tr>
+  <th>Keyword</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><code>x-oold-ui-widget</code></td>
+  <td>Widget hint for a value whose intended widget is not a registered JSON Schema format (for example table, tabs, grid, autocomplete, textarea, checkbox, markdown, color). Registered formats (date, uri, uuid, ...) stay in <code>format</code>. Maps to jedison <code>x-format</code>.</td>
+</tr>
+<tr>
+  <td><code>x-oold-ui-property-order</code></td>
+  <td>Display order of this property within its object or group; lower sorts first. Maps to jedison <code>x-categoryOrder</code>.</td>
+</tr>
+<tr>
+  <td><code>x-oold-ui-property-group</code></td>
+  <td>Name of the group, tab or category this property belongs to. Maps to jedison <code>x-category</code> / <code>x-propGroup</code>.</td>
+</tr>
+<tr>
+  <td><code>x-oold-ui-form-hidden</code></td>
+  <td>Hide this property in the editing form. Maps to jedison <code>x-hidden</code>.</td>
+</tr>
+<tr>
+  <td><code>x-oold-ui-render-hidden</code></td>
+  <td>Hide this property in the rendered (read) view.</td>
+</tr>
+<tr>
+  <td><code>x-oold-ui-enum-titles</code></td>
+  <td>Human display labels for the default language, aligned positionally with <code>enum</code>: the Nth label is the title of the Nth enum value. For <code>enum: [&quot;pi&quot;, &quot;postdoc&quot;, &quot;phd&quot;]</code> the value <code>[&quot;Principal investigator&quot;, &quot;Postdoc&quot;, &quot;PhD student&quot;]</code> labels each option. Localize with <code>x-oold-multilang-ui-enum-titles</code>. Distinct from the identifier-safe code names in <code>x-enum-varnames</code>. Maps to jedison <code>x-enumTitles</code>.</td>
+</tr>
+<tr>
+  <td><code>x-oold-multilang-ui-enum-titles</code></td>
+  <td>BCP-47 language map of <code>x-oold-ui-enum-titles</code> arrays (mirrors <code>x-oold-multilang-title</code>); each array aligns positionally with <code>enum</code>. For <code>enum: [&quot;pi&quot;, &quot;postdoc&quot;, &quot;phd&quot;]</code>: {&quot;en&quot;: [&quot;Principal investigator&quot;, &quot;Postdoc&quot;, &quot;PhD student&quot;], &quot;de&quot;: [&quot;Projektleitung&quot;, &quot;Postdoc&quot;, &quot;Doktorand&quot;]}.</td>
+</tr>
+<tr>
+  <td><code>x-oold-ui-hint</code></td>
+  <td>Short help text shown with the field, in the default language. Localize with <code>x-oold-multilang-ui-hint</code>. Maps to jedison <code>x-info</code>.</td>
+</tr>
+<tr>
+  <td><code>x-oold-multilang-ui-hint</code></td>
+  <td>BCP-47 language map of the <code>x-oold-ui-hint</code> text (mirrors <code>x-oold-multilang-title</code>).</td>
+</tr>
+<tr>
+  <td><code>x-oold-ui-default-property</code></td>
+  <td>Whether this optional property is shown by default in generated user interfaces. Replaces the object-level <code>defaultProperties</code> array: a per-property boolean is overridable under composition (most-derived-wins), so a derived schema can set it false, whereas the merged array form was extend-only.</td>
+</tr>
+<tr>
+  <td><code>x-enum-varnames</code></td>
+  <td>Identifier-safe code names aligned positionally with <code>enum</code>, for code generation. For <code>enum: [&quot;m&quot;, &quot;s&quot;]</code> the value <code>[&quot;metre&quot;, &quot;second&quot;]</code> names each option (so a generator can emit <code>Unit.metre</code> instead of <code>Unit.m</code>). An established vendor extension (OpenAPI Generator; NSwag uses the camelCase <code>x-enumNames</code>). Kept as-is; distinct from the human labels in <code>x-oold-ui-enum-titles</code>.</td>
+</tr>
+<tr>
+  <td><code>x-enum-descriptions</code></td>
+  <td>Per-value descriptions aligned positionally with <code>enum</code>, the established companion of <code>x-enum-varnames</code>. For <code>enum: [&quot;m&quot;, &quot;s&quot;]</code>: <code>[&quot;SI base unit of length&quot;, &quot;SI base unit of time&quot;]</code>.</td>
+</tr>
+</tbody>
+</table>
+<p>The text-valued keywords have a <code>x-oold-multilang-*</code> variant carrying a BCP-47 language map, mirroring <code>x-oold-multilang-title</code> (see <a href="#localizing-schema-annotations"></a>): <code>x-oold-multilang-ui-hint</code> and <code>x-oold-multilang-ui-enum-titles</code>.</p>
+<p>For enum code generation OO-LD keeps the established <code>x-enum-varnames</code> (identifier-safe names aligned with <code>enum</code>) and its companion <code>x-enum-descriptions</code>; these are widely supported vendor extensions (OpenAPI Generator; NSwag's <code>x-enumNames</code>) and are distinct from the human display labels in <code>x-oold-ui-enum-titles</code>.</p>
+<p><code>x-oold-ui-default-property</code> replaces the json-editor <code>defaultProperties</code> array (which listed the optional properties shown initially). That array is <em>extend-only</em> under composition: because composed schemas merge the arrays, a derived schema can add a default property but cannot switch one off. A per-property boolean is <em>overridable</em> - it resolves most-derived-wins (see <a href="#merge-and-override-model"></a>), so a derived schema sets it to <code>false</code> to hide a property a base schema showed. For the same reason <code>x-oold-reverse-default-properties</code> is deprecated in favour of <code>x-oold-ui-default-property</code> on the reverse property.</p></section><section id="widget-hints"><h5>Widget hints: <code>format</code> vs <code>x-oold-ui-widget</code></h5><p><code>format</code> carries the widget hint when its value is a registered JSON Schema 2020-12 format (<code>date</code>, <code>date-time</code>, <code>time</code>, <code>duration</code>, <code>email</code>, <code>uri</code>, <code>iri</code>, <code>uuid</code>, ...); a validator may check it and a form generator picks the matching input. Values that are not registered formats (<code>table</code>, <code>tabs</code>, <code>grid</code>, <code>autocomplete</code>, <code>textarea</code>, <code>checkbox</code>, <code>markdown</code>, <code>color</code>, ...) are widget-only and go in <code>x-oold-ui-widget</code>, leaving <code>format</code> for validation semantics.</p></section><section id="ui-delivery"><h5>Delivery: inline or overlay</h5><p>UI keywords may be embedded in the schema (inline):</p>
+<pre><code class="language-json">{
+  &quot;$schema&quot;: &quot;https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json&quot;,
+  &quot;$id&quot;: &quot;UiAnnotations.schema.json&quot;,
+  &quot;@context&quot;: [
+    {
+      &quot;@version&quot;: 1.1,
+      &quot;schema&quot;: &quot;https://schema.org/&quot;,
+      &quot;name&quot;: &quot;schema:name&quot;,
+      &quot;role&quot;: &quot;schema:jobTitle&quot;,
+      &quot;homepage&quot;: { &quot;@id&quot;: &quot;schema:url&quot;, &quot;@type&quot;: &quot;@id&quot; }
+    }
+  ],
+  &quot;x-oold-uuid&quot;: &quot;b1e7a0c2-2d4f-4a1e-9c3a-7f0e5d2b6a11&quot;,
+  &quot;title&quot;: &quot;Researcher&quot;,
+  &quot;x-oold-multilang-title&quot;: { &quot;en&quot;: &quot;Researcher&quot;, &quot;de&quot;: &quot;Forschende Person&quot; },
+  &quot;x-oold-iri&quot;: &quot;schema:Person&quot;,
+  &quot;type&quot;: &quot;object&quot;,
+  &quot;properties&quot;: {
+    &quot;name&quot;: {
+      &quot;type&quot;: &quot;string&quot;,
+      &quot;title&quot;: &quot;Name&quot;,
+      &quot;x-oold-ui-default-property&quot;: true,
+      &quot;x-oold-ui-property-order&quot;: 1,
+      &quot;x-oold-ui-property-group&quot;: &quot;General&quot;,
+      &quot;x-oold-ui-hint&quot;: &quot;Full name&quot;,
+      &quot;x-oold-multilang-ui-hint&quot;: { &quot;en&quot;: &quot;Full name&quot;, &quot;de&quot;: &quot;Vollständiger Name&quot; }
+    },
+    &quot;role&quot;: {
+      &quot;type&quot;: &quot;string&quot;,
+      &quot;title&quot;: &quot;Role&quot;,
+      &quot;enum&quot;: [&quot;pi&quot;, &quot;postdoc&quot;, &quot;phd&quot;],
+      &quot;x-enum-varnames&quot;: [&quot;PrincipalInvestigator&quot;, &quot;PostDoc&quot;, &quot;PhDStudent&quot;],
+      &quot;x-enum-descriptions&quot;: [&quot;Leads the project&quot;, &quot;Holds a doctorate&quot;, &quot;Doctoral candidate&quot;],
+      &quot;x-oold-ui-enum-titles&quot;: [&quot;Principal investigator&quot;, &quot;Postdoc&quot;, &quot;PhD student&quot;],
+      &quot;x-oold-multilang-ui-enum-titles&quot;: { &quot;en&quot;: [&quot;Principal investigator&quot;, &quot;Postdoc&quot;, &quot;PhD student&quot;], &quot;de&quot;: [&quot;Projektleitung&quot;, &quot;Postdoc&quot;, &quot;Doktorand&quot;] },
+      &quot;x-oold-ui-property-order&quot;: 2,
+      &quot;x-oold-ui-property-group&quot;: &quot;General&quot;
+    },
+    &quot;homepage&quot;: {
+      &quot;type&quot;: &quot;string&quot;,
+      &quot;title&quot;: &quot;Homepage&quot;,
+      &quot;format&quot;: &quot;uri&quot;,
+      &quot;x-oold-ui-property-group&quot;: &quot;Contact&quot;
+    },
+    &quot;notes&quot;: {
+      &quot;type&quot;: &quot;string&quot;,
+      &quot;title&quot;: &quot;Notes&quot;,
+      &quot;x-oold-ui-widget&quot;: &quot;markdown&quot;,
+      &quot;x-oold-ui-property-group&quot;: &quot;Contact&quot;
+    },
+    &quot;internal_id&quot;: {
+      &quot;type&quot;: &quot;string&quot;,
+      &quot;title&quot;: &quot;Internal id&quot;,
+      &quot;x-oold-ui-form-hidden&quot;: true
+    }
+  }
+}
+</code></pre>
+<p>or applied by an <em>overlay</em> - a separate document that patches a schema without editing it, following the <a href="https://spec.openapis.org/overlay/latest.html">OpenAPI Overlay 1.1.0</a> model. Overlays are a general schema-patching mechanism: the <code>update</code> actions can inject any keywords (semantics, constraints or presentation), and applying <code>x-oold-ui-*</code> annotations is one use case - useful when the schema is generated or owned elsewhere, or when one schema needs different presentation in different contexts. An overlay lists <code>actions</code>, each selecting nodes with an <a href="https://www.rfc-editor.org/rfc/rfc9535">RFC 9535 JSONPath</a> <code>target</code> and merging keys via <code>update</code> (or removing them via <code>remove</code>):</p>
+<pre><code class="language-json">{
+  &quot;overlay&quot;: &quot;1.0.0&quot;,
+  &quot;info&quot;: {
+    &quot;title&quot;: &quot;Researcher admin overlay&quot;,
+    &quot;version&quot;: &quot;1.0.0&quot;,
+    &quot;description&quot;: &quot;Applies presentation-only x-oold-ui-* keywords to Researcher without editing the schema. An overlay is a general schema-patching mechanism (OpenAPI Overlay 1.1.0); UI annotation is one use case.&quot;
+  },
+  &quot;extends&quot;: &quot;./UiAnnotations.schema.json&quot;,
+  &quot;actions&quot;: [
+    {
+      &quot;target&quot;: &quot;$.properties.internal_id&quot;,
+      &quot;description&quot;: &quot;Show the internal id for admins.&quot;,
+      &quot;update&quot;: { &quot;x-oold-ui-form-hidden&quot;: false }
+    },
+    {
+      &quot;target&quot;: &quot;$.properties.notes&quot;,
+      &quot;description&quot;: &quot;Render notes as a plain textarea instead of markdown.&quot;,
+      &quot;update&quot;: { &quot;x-oold-ui-widget&quot;: &quot;textarea&quot; }
+    },
+    {
+      &quot;target&quot;: &quot;$.properties.role&quot;,
+      &quot;description&quot;: &quot;Drop the render-time grouping for a flat admin form.&quot;,
+      &quot;remove&quot;: false,
+      &quot;update&quot;: { &quot;x-oold-ui-property-group&quot;: &quot;Identity&quot; }
+    }
+  ]
+}
+</code></pre>
+<p>The vendor keywords are documented by their respective projects: jedison's <code>x-jedison-*</code> (see <a href="https://github.com/germanbisurgi/jedison/issues/58">germanbisurgi/jedison#58</a> and the overlay proposal <a href="https://github.com/germanbisurgi/jedison/issues/59">#59</a>) and, for schemas coming from OpenSemanticLab, the server-side <code>x-osl-*</code> keywords. Migrating a legacy OpenSemanticWorld schema to these keywords is covered in the <a href="../migration/from-legacy-osw/">migration guide</a>.</p></section></section></section></section>
 
 <section id="meta-schema"><h2>Meta-schema and Vocabulary</h2><p>OO-LD adds keywords on top of JSON Schema 2020-12. All OO-LD-proprietary keywords are prefixed with <code>x-oold-</code> so they are valid <a href="https://json-schema.org/draft/2020-12/json-schema-core#section-6.5">JSON Schema extension keywords</a> and, at the same time, valid <a href="https://spec.openapis.org/oas/v3.0.3.html#specification-extensions">OpenAPI 3.0 Specification Extensions</a> (OpenAPI 3.0 rejects unprefixed custom keywords in a Schema object). The only non-prefixed OO-LD-specific entry is <code>@context</code>, which is a JSON-LD keyword and cannot be renamed.</p>
 <p>The OO-LD dialect is described by a meta-schema ([[OOLD-META]]). It extends the standard 2020-12 meta-schema and adds the syntax of the <code>x-oold-*</code> keywords, so an OO-LD schema can be validated <em>as</em> an OO-LD schema. The meta-schema declares its vocabularies via <code>$vocabulary</code>: the seven standard 2020-12 vocabularies are re-listed as required (they are not inherited through <code>$ref</code>, [[JSONSCHEMA]] §8.1.2.2), and the OO-LD vocabulary is declared <strong>optional</strong> (<code>false</code>) so that generic 2020-12 validators still process OO-LD schemas instead of refusing them.</p>
@@ -659,7 +813,7 @@ intersections (<code>allOf</code>) and inline constraints can be combined to des
 </tr>
 <tr>
   <td><code>x-oold-reverse-default-properties</code></td>
-  <td>Names of reverse properties shown by default in generated user interfaces.</td>
+  <td>Deprecated. Names of reverse properties shown by default in generated user interfaces. Like the object-level defaultProperties array this is extend-only under composition; prefer a per-reverse-property x-oold-ui-default-property boolean, which is overridable.</td>
 </tr>
 </tbody>
 </table></section>

--- a/examples/UiAnnotations.schema.json
+++ b/examples/UiAnnotations.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json",
+  "$id": "UiAnnotations.schema.json",
+  "@context": [
+    {
+      "@version": 1.1,
+      "schema": "https://schema.org/",
+      "name": "schema:name",
+      "role": "schema:jobTitle",
+      "homepage": { "@id": "schema:url", "@type": "@id" }
+    }
+  ],
+  "x-oold-uuid": "b1e7a0c2-2d4f-4a1e-9c3a-7f0e5d2b6a11",
+  "title": "Researcher",
+  "x-oold-multilang-title": { "en": "Researcher", "de": "Forschende Person" },
+  "x-oold-iri": "schema:Person",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Name",
+      "x-oold-ui-default-property": true,
+      "x-oold-ui-property-order": 1,
+      "x-oold-ui-property-group": "General",
+      "x-oold-ui-hint": "Full name",
+      "x-oold-multilang-ui-hint": { "en": "Full name", "de": "Vollständiger Name" }
+    },
+    "role": {
+      "type": "string",
+      "title": "Role",
+      "enum": ["pi", "postdoc", "phd"],
+      "x-enum-varnames": ["PrincipalInvestigator", "PostDoc", "PhDStudent"],
+      "x-enum-descriptions": ["Leads the project", "Holds a doctorate", "Doctoral candidate"],
+      "x-oold-ui-enum-titles": ["Principal investigator", "Postdoc", "PhD student"],
+      "x-oold-multilang-ui-enum-titles": { "en": ["Principal investigator", "Postdoc", "PhD student"], "de": ["Projektleitung", "Postdoc", "Doktorand"] },
+      "x-oold-ui-property-order": 2,
+      "x-oold-ui-property-group": "General"
+    },
+    "homepage": {
+      "type": "string",
+      "title": "Homepage",
+      "format": "uri",
+      "x-oold-ui-property-group": "Contact"
+    },
+    "notes": {
+      "type": "string",
+      "title": "Notes",
+      "x-oold-ui-widget": "markdown",
+      "x-oold-ui-property-group": "Contact"
+    },
+    "internal_id": {
+      "type": "string",
+      "title": "Internal id",
+      "x-oold-ui-form-hidden": true
+    }
+  }
+}

--- a/examples/UiOverlay.json
+++ b/examples/UiOverlay.json
@@ -1,0 +1,27 @@
+{
+  "overlay": "1.0.0",
+  "info": {
+    "title": "Researcher admin overlay",
+    "version": "1.0.0",
+    "description": "Applies presentation-only x-oold-ui-* keywords to Researcher without editing the schema. An overlay is a general schema-patching mechanism (OpenAPI Overlay 1.1.0); UI annotation is one use case."
+  },
+  "extends": "./UiAnnotations.schema.json",
+  "actions": [
+    {
+      "target": "$.properties.internal_id",
+      "description": "Show the internal id for admins.",
+      "update": { "x-oold-ui-form-hidden": false }
+    },
+    {
+      "target": "$.properties.notes",
+      "description": "Render notes as a plain textarea instead of markdown.",
+      "update": { "x-oold-ui-widget": "textarea" }
+    },
+    {
+      "target": "$.properties.role",
+      "description": "Drop the render-time grouping for a flat admin form.",
+      "remove": false,
+      "update": { "x-oold-ui-property-group": "Identity" }
+    }
+  ]
+}

--- a/meta/oold-meta-schema.json
+++ b/meta/oold-meta-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json",
   "$dynamicAnchor": "meta",
   "title": "OO-LD dialect meta-schema",
-  "$comment": "Provisional $id and OO-LD vocabulary URI - to be finalized when the canonical hosting location is decided. The OO-LD vocabulary is declared optional (false) so that generic JSON-Schema 2020-12 validators still process OO-LD schemas.",
+  "$comment": "The $id uses the versioned hosting at oo-ld.github.io/oold-schema/ (the source keeps the /latest/ placeholder; each released copy is stamped per release). The OO-LD vocabulary is declared optional (false) so that generic JSON-Schema 2020-12 validators still process OO-LD schemas. The UI keyword definitions are included via the oold-ui-meta-schema #keywords anchor so a schema carrying x-oold-ui-* annotations validates in one pass.",
   "$vocabulary": {
     "https://json-schema.org/draft/2020-12/vocab/core": true,
     "https://json-schema.org/draft/2020-12/vocab/applicator": true,
@@ -15,7 +15,8 @@
     "https://oo-ld.github.io/oold-schema/latest/vocab/oold": false
   },
   "allOf": [
-    { "$ref": "https://json-schema.org/draft/2020-12/schema" }
+    { "$ref": "https://json-schema.org/draft/2020-12/schema" },
+    { "$ref": "https://oo-ld.github.io/oold-schema/latest/meta/oold-ui-meta-schema.json#keywords" }
   ],
   "properties": {
     "@context": {
@@ -89,7 +90,8 @@
       "items": { "type": "string" }
     },
     "x-oold-reverse-default-properties": {
-      "description": "Names of reverse properties shown by default in generated user interfaces.",
+      "description": "Deprecated. Names of reverse properties shown by default in generated user interfaces. Like the object-level defaultProperties array this is extend-only under composition; prefer a per-reverse-property x-oold-ui-default-property boolean, which is overridable.",
+      "deprecated": true,
       "type": "array",
       "items": { "type": "string" }
     }

--- a/meta/oold-ui-meta-schema.json
+++ b/meta/oold-ui-meta-schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://oo-ld.github.io/oold-schema/latest/meta/oold-ui-meta-schema.json",
+  "$dynamicAnchor": "meta",
+  "title": "OO-LD UI dialect meta-schema",
+  "$comment": "The $id uses the versioned hosting at oo-ld.github.io/oold-schema/ (the source keeps the /latest/ placeholder; each released copy is stamped per release). The oold-ui vocabulary is declared optional (false) so that generic JSON-Schema 2020-12 validators still process the schema. The x-oold-ui-* keyword definitions live in $defs.keywords (plain anchor #keywords) so the main OO-LD meta-schema can include just them, without re-introducing the 2020-12 reference or a second dynamic anchor. Each keyword carries a description and an example so the vocabulary can be rendered into documentation. As with the core dialect, this meta-schema only validates that the keywords are well-formed; the behaviour is supplied by OO-LD-aware form generators (for example jedison).",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+    "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+    "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+    "https://json-schema.org/draft/2020-12/vocab/content": true,
+    "https://oo-ld.github.io/oold-schema/latest/vocab/oold-ui": false
+  },
+  "allOf": [
+    { "$ref": "https://json-schema.org/draft/2020-12/schema" },
+    { "$ref": "#keywords" }
+  ],
+  "$defs": {
+    "keywords": {
+      "$anchor": "keywords",
+      "properties": {
+        "x-oold-ui-widget": {
+          "description": "Widget hint for a value whose intended widget is not a registered JSON Schema format (for example table, tabs, grid, autocomplete, textarea, checkbox, markdown, color). Registered formats (date, uri, uuid, ...) stay in `format`. Maps to jedison `x-format`.",
+          "type": "string",
+          "examples": ["table", "autocomplete", "markdown"]
+        },
+        "x-oold-ui-property-order": {
+          "description": "Display order of this property within its object or group; lower sorts first. Maps to jedison `x-categoryOrder`.",
+          "type": "integer",
+          "examples": [1]
+        },
+        "x-oold-ui-property-group": {
+          "description": "Name of the group, tab or category this property belongs to. Maps to jedison `x-category` / `x-propGroup`.",
+          "type": "string",
+          "examples": ["General", "Contact"]
+        },
+        "x-oold-ui-form-hidden": {
+          "description": "Hide this property in the editing form. Maps to jedison `x-hidden`.",
+          "type": "boolean",
+          "examples": [true]
+        },
+        "x-oold-ui-render-hidden": {
+          "description": "Hide this property in the rendered (read) view.",
+          "type": "boolean",
+          "examples": [true]
+        },
+        "x-oold-ui-enum-titles": {
+          "description": "Human display labels for the default language, aligned positionally with `enum`: the Nth label is the title of the Nth enum value. For `enum: [\"pi\", \"postdoc\", \"phd\"]` the value `[\"Principal investigator\", \"Postdoc\", \"PhD student\"]` labels each option. Localize with `x-oold-multilang-ui-enum-titles`. Distinct from the identifier-safe code names in `x-enum-varnames`. Maps to jedison `x-enumTitles`.",
+          "type": "array",
+          "items": { "type": "string" },
+          "examples": [["Principal investigator", "Postdoc", "PhD student"]]
+        },
+        "x-oold-multilang-ui-enum-titles": {
+          "description": "BCP-47 language map of `x-oold-ui-enum-titles` arrays (mirrors `x-oold-multilang-title`); each array aligns positionally with `enum`. For `enum: [\"pi\", \"postdoc\", \"phd\"]`: {\"en\": [\"Principal investigator\", \"Postdoc\", \"PhD student\"], \"de\": [\"Projektleitung\", \"Postdoc\", \"Doktorand\"]}.",
+          "type": "object",
+          "additionalProperties": { "type": "array", "items": { "type": "string" } },
+          "examples": [{ "en": ["Principal investigator", "Postdoc", "PhD student"], "de": ["Projektleitung", "Postdoc", "Doktorand"] }]
+        },
+        "x-oold-ui-hint": {
+          "description": "Short help text shown with the field, in the default language. Localize with `x-oold-multilang-ui-hint`. Maps to jedison `x-info`.",
+          "type": "string",
+          "examples": ["Full name"]
+        },
+        "x-oold-multilang-ui-hint": {
+          "description": "BCP-47 language map of the `x-oold-ui-hint` text (mirrors `x-oold-multilang-title`).",
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "examples": [{ "en": "Full name", "de": "Vollständiger Name" }]
+        },
+        "x-oold-ui-default-property": {
+          "description": "Whether this optional property is shown by default in generated user interfaces. Replaces the object-level `defaultProperties` array: a per-property boolean is overridable under composition (most-derived-wins), so a derived schema can set it false, whereas the merged array form was extend-only.",
+          "type": "boolean",
+          "examples": [true]
+        },
+        "x-enum-varnames": {
+          "description": "Identifier-safe code names aligned positionally with `enum`, for code generation. For `enum: [\"m\", \"s\"]` the value `[\"metre\", \"second\"]` names each option (so a generator can emit `Unit.metre` instead of `Unit.m`). An established vendor extension (OpenAPI Generator; NSwag uses the camelCase `x-enumNames`). Kept as-is; distinct from the human labels in `x-oold-ui-enum-titles`.",
+          "type": "array",
+          "items": { "type": "string" },
+          "examples": [["metre", "second"]]
+        },
+        "x-enum-descriptions": {
+          "description": "Per-value descriptions aligned positionally with `enum`, the established companion of `x-enum-varnames`. For `enum: [\"m\", \"s\"]`: `[\"SI base unit of length\", \"SI base unit of time\"]`.",
+          "type": "array",
+          "items": { "type": "string" },
+          "examples": [["SI base unit of length", "SI base unit of time"]]
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.0.0",
-    "ajv": "^8.12.0"
+    "ajv": "^8.12.0",
+    "ajv-formats": "^3.0.1"
   }
 }

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -8,6 +8,7 @@
 // x-oold-ref / x-oold-range and @context references are intentionally NOT auto-resolved;
 // they are handled by OO-LD-aware tooling.
 import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
 import $RefParser from "@apidevtools/json-schema-ref-parser";
 import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -15,10 +16,16 @@ import { dirname, join } from "node:path";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const meta = JSON.parse(readFileSync(join(root, "meta", "oold-meta-schema.json"), "utf8"));
+const uiMeta = JSON.parse(readFileSync(join(root, "meta", "oold-ui-meta-schema.json"), "utf8"));
 const exDir = join(root, "examples");
 const files = readdirSync(exDir).filter((f) => f.endsWith(".schema.json"));
 
-const ajv = new Ajv2020({ strict: false });
+// validateFormats: true (ajv default) + ajv-formats turns `format` into an
+// assertion, so uri/uri-reference/uuid/date-time in the examples and meta-schemas
+// are actually checked rather than annotated-and-ignored.
+const ajv = new Ajv2020({ strict: false, validateFormats: true });
+addFormats(ajv);
+ajv.addSchema(uiMeta); // so the core meta-schema can $ref the UI keyword definitions
 const validateAsOOLD = ajv.compile(meta); // also validates the meta-schema against 2020-12
 
 let failures = 0;

--- a/spec/sections/09-extensions.md
+++ b/spec/sections/09-extensions.md
@@ -227,7 +227,7 @@ A range subschema MAY also carry additional annotations (e.g. `title`, `descript
 
 #### Reverse properties {#reverse-properties}
 
-Many relations are symmetric (e.g. Organization employs Person ⇔ Person works for Organization) and users want to edit them from both sides, without storing the information twice. The keywords `x-oold-reverse-properties`, `x-oold-reverse-default-properties` and `x-oold-reverse-required` declare such a [=reverse property=], mapped with JSON-LD `@reverse` in the `@context`. To make `employees` the reverse of `organization`:
+Many relations are symmetric (e.g. Organization employs Person ⇔ Person works for Organization) and users want to edit them from both sides, without storing the information twice. The keywords `x-oold-reverse-properties` and `x-oold-reverse-required` declare such a [=reverse property=], mapped with JSON-LD `@reverse` in the `@context`. (The earlier `x-oold-reverse-default-properties` array is deprecated: mark a reverse property shown by default with `x-oold-ui-default-property` on the property itself - see [](#ui-generation) - which, unlike the merged array, is overridable under composition.) To make `employees` the reverse of `organization`:
 
 - define `employees` in `x-oold-reverse-properties` of `Organization`;
 - define `organization` in the `properties` of `Person`;
@@ -245,11 +245,11 @@ Many relations are symmetric (e.g. Organization employs Person ⇔ Person works 
   "type": "object",
   "required": ["type"],
   "x-oold-reverse-required": [],
-  "x-oold-reverse-default-properties": ["employees"],
   "x-oold-reverse-properties": {
     "employees": {
       "type": "array",
       "title": "Employees",
+      "x-oold-ui-default-property": true,
       "items": {
         "type": "string",
         "format": "autocomplete",
@@ -289,4 +289,37 @@ An OO-LD-aware implementation uses this to read and modify properties that are a
 
 #### UI Generation {#ui-generation .informative}
 
-Additional keywords defined by [JSON Editor](https://github.com/json-editor/json-editor) (see its [basic features](https://github.com/json-editor/json-editor#readme) and [add-on details](https://github.com/json-editor/json-editor/blob/master/README_ADDON.md)) MAY be used to drive automatic user-interface (form) generation.
+OO-LD schemas double as the source for auto-generated forms and views. UI intent is carried in two layers:
+
+- Portable, renderer-agnostic keywords in the `x-oold-ui-*` vocabulary, defined here. Any form generator can honour them.
+- Renderer-specific keywords passed through under a vendor prefix - `x-jedison-*` for [jedison](https://github.com/germanbisurgi/jedison), the successor of [json-editor](https://github.com/json-editor/json-editor) - for options that do not generalize.
+
+Every keyword keeps the `x-` prefix, so it is a valid JSON Schema extension keyword and a valid OpenAPI 3.0 specification extension, and generic 2020-12 validators ignore it. The `x-oold-ui-*` keywords form their own optional dialect, described by the [OO-LD UI meta-schema](../meta/oold-ui-meta-schema.json); the core meta-schema includes those definitions so an OO-LD schema carrying UI annotations validates in one pass.
+
+##### The `x-oold-ui-*` vocabulary {#ui-vocabulary}
+
+All keywords apply to the (sub)schema of a single property.
+
+{{ render_schema('meta/oold-ui-meta-schema.json') }}
+
+The text-valued keywords have a `x-oold-multilang-*` variant carrying a BCP-47 language map, mirroring `x-oold-multilang-title` (see [](#localizing-schema-annotations)): `x-oold-multilang-ui-hint` and `x-oold-multilang-ui-enum-titles`.
+
+For enum code generation OO-LD keeps the established `x-enum-varnames` (identifier-safe names aligned with `enum`) and its companion `x-enum-descriptions`; these are widely supported vendor extensions (OpenAPI Generator; NSwag's `x-enumNames`) and are distinct from the human display labels in `x-oold-ui-enum-titles`.
+
+`x-oold-ui-default-property` replaces the json-editor `defaultProperties` array (which listed the optional properties shown initially). That array is *extend-only* under composition: because composed schemas merge the arrays, a derived schema can add a default property but cannot switch one off. A per-property boolean is *overridable* - it resolves most-derived-wins (see [](#merge-and-override-model)), so a derived schema sets it to `false` to hide a property a base schema showed. For the same reason `x-oold-reverse-default-properties` is deprecated in favour of `x-oold-ui-default-property` on the reverse property.
+
+##### Widget hints: `format` vs `x-oold-ui-widget` {#widget-hints}
+
+`format` carries the widget hint when its value is a registered JSON Schema 2020-12 format (`date`, `date-time`, `time`, `duration`, `email`, `uri`, `iri`, `uuid`, ...); a validator may check it and a form generator picks the matching input. Values that are not registered formats (`table`, `tabs`, `grid`, `autocomplete`, `textarea`, `checkbox`, `markdown`, `color`, ...) are widget-only and go in `x-oold-ui-widget`, leaving `format` for validation semantics.
+
+##### Delivery: inline or overlay {#ui-delivery}
+
+UI keywords may be embedded in the schema (inline):
+
+{{ example('UiAnnotations') }}
+
+or applied by an *overlay* - a separate document that patches a schema without editing it, following the [OpenAPI Overlay 1.1.0](https://spec.openapis.org/overlay/latest.html) model. Overlays are a general schema-patching mechanism: the `update` actions can inject any keywords (semantics, constraints or presentation), and applying `x-oold-ui-*` annotations is one use case - useful when the schema is generated or owned elsewhere, or when one schema needs different presentation in different contexts. An overlay lists `actions`, each selecting nodes with an [RFC 9535 JSONPath](https://www.rfc-editor.org/rfc/rfc9535) `target` and merging keys via `update` (or removing them via `remove`):
+
+{{ inline_file('examples/UiOverlay.json') }}
+
+The vendor keywords are documented by their respective projects: jedison's `x-jedison-*` (see [germanbisurgi/jedison#58](https://github.com/germanbisurgi/jedison/issues/58) and the overlay proposal [#59](https://github.com/germanbisurgi/jedison/issues/59)) and, for schemas coming from OpenSemanticLab, the server-side `x-osl-*` keywords. Migrating a legacy OpenSemanticWorld schema to these keywords is covered in the [migration guide](../migration/from-legacy-osw/).


### PR DESCRIPTION
Addresses #30. Defines the OO-LD UI annotation vocabulary and a UI dialect meta-schema, grounded in the legacy keyword inventory (PR #61) and aligned with the jedison renderer.

## What is here

- \`meta/oold-ui-meta-schema.json\` - the UI dialect meta-schema. Declares its own optional \`$vocabulary\` and defines the renderer-agnostic \`x-oold-ui-*\` keywords (\`widget\`, \`property-order\`, \`property-group\`, \`form-hidden\`, \`render-hidden\`, \`enum-titles\`, \`hint\`, \`default-property\`), their \`x-oold-multilang-ui-*\` variants, and the adopted \`x-enum-varnames\` / \`x-enum-descriptions\`. Every keyword carries a description and an example (enum-aligned keywords show the corresponding \`enum\`) so the vocab can be rendered into docs. Definitions sit behind a \`#keywords\` anchor.
- \`meta/oold-meta-schema.json\` - includes the UI keyword definitions via \`$ref\` (so a schema with UI annotations validates in one pass) and deprecates \`x-oold-reverse-defaultProperties\`.
- \`scripts/validate.mjs\` - loads the UI meta-schema; \`npm run validate\` now covers UI keywords (verified: an invalid \`x-oold-ui-property-order\` is rejected at nested property level).
- \`README.md\` - rewrites the UI Generation stub into a full section: the \`x-oold-ui-*\` table with jedison mappings, \`format\` vs \`x-oold-ui-widget\`, the extend-only vs overridable rationale for \`x-oold-ui-default-property\`, the multilang variants, and inline vs overlay delivery (overlays framed as a general schema-patching mechanism per OpenAPI Overlay 1.1.0, with UI as one use case). Migrates the reverse-properties example to the new keywords and notes the single-hop limitation of reverse properties in the UI.
- \`examples/UiAnnotations.schema.json\`, \`examples/UiOverlay.json\` - examples (the schema validates).

## Design decisions

- Native \`x-oold-ui-*\` for portable UI intent; vendor \`x-jedison-*\` (rendering) and \`x-osl-*\` (OSL server-side) for keywords that do not generalize. Flat keywords, consistent with existing \`x-oold-*\`. See jedison #58 / #59.
- \`x-oold-ui-default-property\` (per-property boolean, overridable most-derived-wins) replaces the extend-only \`defaultProperties\` array; same for the reverse form.
- Text-valued keywords follow the established \`x-oold-multilang-*\` pattern rather than overloading the base keyword.

The vocab \`description\`+\`examples\` are docs-generator-ready (e.g. @adobe/jsonschema2md or json-schema-for-humans) for the publishing pipeline (#26).

Depends on PR #61 for the \`docs/migration/from-legacy-osw.md\` link target; both merge to \`main\`. Relates to #15, #58, #59.