### PR TITLE
docs: versioned docs + schemas via mike (latest default, /X.Y.Z/ static URLs)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,14 +2,17 @@ name: main
 
 on:
   push:
+    branches: [main]
+    tags: ["v*"]
   pull_request:
   workflow_dispatch:
 
-# Pin the zensical version here so documentation builds are reproducible.
+# Pin zensical (docs build) and the zensical fork of mike (versioning bridge)
+# for reproducible builds/deploys.
 env:
   ZENSICAL_VERSION: "0.0.46"
+  MIKE_SPEC: "git+https://github.com/squidfunk/mike.git@2.2.0+zensical-0.1.0"
 
-# Allow only one concurrent Pages deployment.
 concurrency:
   group: pages-${{ github.ref }}
   cancel-in-progress: false
@@ -27,9 +30,9 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - run: npm install
       - run: npm run validate
-      # Re-render the spec from spec/sections + meta/*.json, fail if the committed
-      # docs/spec/index.html is stale (drift guard), then lint its structure.
-      # (Renderer dependencies are pinned inline in the script via PEP 723.)
+      # Re-render the spec and fail if the committed docs/spec/index.html is stale
+      # (drift guard), then lint its structure. Renderer deps are pinned inline
+      # via PEP 723, so `uv run` stays reproducible.
       - name: Render the spec
         run: uv run scripts/render_spec.py
       - name: Check the generated spec is up to date
@@ -37,36 +40,49 @@ jobs:
       - name: Lint the spec
         run: uv run scripts/check_spec.py
 
-  # Build the documentation on every push/PR, but only after schema validation
-  # succeeds - so the site is only ever published from valid schema definitions.
-  # On a push to `main` the built site is uploaded as a Pages artifact for the
-  # deploy job; on PRs this job is a build-only check (no upload, no deploy).
-  docs-build:
+  # Publish the versioned docs + schemas to the `gh-pages` branch with mike (the
+  # zensical fork). GitHub Pages must serve from `gh-pages`
+  # (Settings > Pages > Source: Deploy from a branch > gh-pages).
+  # meta/ + examples/ are staged into docs/ so every version also serves them at
+  # /<ver>/meta and /<ver>/schemas. main -> the `dev` version; a `vX.Y.Z` tag ->
+  # version `X.Y` with the `latest` alias (and root redirect via set-default).
+  deploy:
     needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # mike pushes to gh-pages
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-      - name: Build documentation
-        run: uvx zensical@${{ env.ZENSICAL_VERSION }} build --clean
-      - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v4
         with:
-          path: site
-
-  deploy-docs:
-    needs: docs-build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v6
+      - name: Stage schemas into the site
+        run: make stage-schemas
+      # mike commits the built site to gh-pages; GitHub runners have no default
+      # git identity, so `git commit` would fail without this.
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Build only (pull request)
+        if: github.event_name != 'push'
+        run: uvx zensical@${{ env.ZENSICAL_VERSION }} build --clean
+      - name: Publish dev (push to main)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          # Stamp the served schema copies with this version id so they self-identify
+          # (the source keeps the /latest/ placeholder; staged copies are gitignored).
+          sed -i 's#/oold-schema/latest/#/oold-schema/dev/#g' docs/meta/*.json docs/schemas/*.json
+          uvx --from "$MIKE_SPEC" mike deploy --push dev
+      - name: Publish release (tag vX.Y.Z)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          ver="${GITHUB_REF_NAME#v}"   # full semver (e.g. 0.4.0) -> served at /0.4.0/, matching OO-LD package-versioning
+          # Stamp the concrete version into the served schemas so /X.Y.Z/ self-identifies
+          # (spec-compliant + reproducible); the source keeps the /latest/ placeholder.
+          sed -i "s#/oold-schema/latest/#/oold-schema/$ver/#g" docs/meta/*.json docs/schemas/*.json
+          # --alias-type=copy so /latest/ is a real directory (its schema JSON is
+          # fetchable; a redirect alias would 404 for machine schema references).
+          MIKE="uvx --from $MIKE_SPEC mike"
+          $MIKE deploy --push --alias-type=copy --update-aliases "$ver" latest
+          $MIKE set-default --push latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ package-lock.json
 site/
 .venv/
 __pycache__/
+
+# staged into the versioned site by the build (canonical sources are meta/ and examples/)
+docs/meta/
+docs/schemas/

--- a/Makefile
+++ b/Makefile
@@ -24,16 +24,22 @@ spec: ## Regenerate docs/spec/index.html from spec/sections + meta/*.json (via u
 	@echo "🚀 Rendering the ReSpec spec from spec/"
 	@uv run scripts/render_spec.py
 
+.PHONY: stage-schemas
+stage-schemas: ## Copy meta/ + examples/ into docs/ so the build serves them (versioned per release)
+	@mkdir -p docs/meta docs/schemas
+	@cp meta/*.json docs/meta/
+	@cp examples/*.schema.json docs/schemas/
+
 .PHONY: docs
-docs: ## Serve the docs with live reload (serves the committed spec artifact)
+docs: stage-schemas ## Serve the docs with live reload (serves the committed spec artifact)
 	@$(ZENSICAL) serve
 
 .PHONY: preview
-preview: spec ## Regenerate the spec, then serve the docs with live reload
+preview: spec stage-schemas ## Regenerate the spec, then serve the docs with live reload
 	@$(ZENSICAL) serve
 
 .PHONY: check
-check: validate spec ## Validate schemas, lint the regenerated spec, and build the site
+check: validate spec stage-schemas ## Validate schemas, lint the regenerated spec, and build the site
 	@uv run scripts/check_spec.py
 	@$(ZENSICAL) build --clean
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -6,25 +6,11 @@ This page walks you through the smallest possible OO-LD schema, step by step. If
 
 The core idea of OO-LD is that a single document is at once a valid **JSON Schema** and a reference-able **JSON-LD remote context**. Start from a plain JSON Schema and add an `@context`:
 
-```json
-{
-  "@context": {
-    "schema": "http://schema.org/",
-    "name": "schema:name"
-  },
-  "title": "Person",
-  "type": "object",
-  "properties": {
-    "name": {
-      "type": "string",
-      "description": "First and Last name"
-    }
-  }
-}
-```
+{{ example('Minimal') }}
 
-- The JSON Schema part (`type`, `properties`, …) describes the **structure** of a `Person` object.
+- The JSON Schema part (`type`, `properties`, …) describes the **structure** of the object.
 - The `@context` part maps the `name` property to the semantic term `schema:name`, describing its **meaning**.
+- `$id` gives the schema a stable identity and `$schema` declares the OO-LD dialect (the meta-schema).
 
 ## Step 2 - Try it in the playground
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,23 +1,6 @@
 # Reference
 
-This page collects the normative reference material: IANA / media-type considerations, the registry, references, and a comparison with related work.
-
-## IANA Considerations
-
-| Slot   | File extension (recommended) | Media type                              | RFC6906 profile                        | Description                                                                                         |
-| ------ | ---------------------------- | --------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| schema | *.schema.json                | `application/oold-schema+json`          | -                                      | Full OO-LD schema                                                                                   |
-| schema | *.schema.json                | `application/oold-schema+json`          | oold-schema#bundled                    | Full OO-LD schema with all `$ref` and remote context bundled                                        |
-| schema | *.schema.json                | `application/oold-schema+json`          | <http://www.w3.org/ns/json-ld#context> | Only the JSON-LD context                                                                            |
-| schema | *.schema.json                | `application/ld+json`                   | -                                      | Only the JSON-LD context                                                                            |
-| schema | *.schema.json                | `application/schema+json`               | -                                      | Only the JSON Schema schema                                                                         |
-| data   | *.data.json                  | `application/oold-schema-instance+json` | -                                      | Full OO-LD instance                                                                                 |
-| data   | *.data.json                  | `application/ld+json`                   | <http://www.w3.org/ns/json-ld#>*       | Full OO-LD instance. Profiles defined in <https://www.w3.org/TR/json-ld/#iana-considerations> apply |
-| data   | *.data.json                  | `application/json`                      | -                                      | Only the JSON data                                                                                  |
-
-### Security considerations
-
-Both security consideration of [JSON-LD v1.1 section C](https://www.w3.org/TR/2020/REC-json-ld11-20200716/#iana-considerations) and [JSON Schema 2020-12 section 13](https://json-schema.org/draft/2020-12/json-schema-core#section-13) apply.
+This page collects informative reference material - the package registry, discussion pointers, and a comparison with related work. The normative IANA / media-type considerations, security considerations, and the bibliography are in the [Specification](spec/index.html).
 
 ## Registry
 
@@ -26,22 +9,6 @@ Both security consideration of [JSON-LD v1.1 section C](https://www.w3.org/TR/20
 ## Discussion
 
 - In the context of YAML-LD: <https://github.com/json-ld/yaml-ld/issues/19>
-
-## Normative References
-
-|                                          |                                                                                                                                                                                                        |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| <a id="RFC2119"></a>RFC 2119             | Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, DOI 10.17487/RFC2119,                     March 1997, <https://www.rfc-editor.org/info/rfc2119>.            |
-| <a id="RFC8259"></a>RFC 8259             | Bray, T., Ed., "The JavaScript Object Notation (JSON) Data Interchange Format", STD 90, RFC 8259, DOI 10.17487/RFC8259,                      December 2017, <https://www.rfc-editor.org/info/rfc8259>. |
-| <a id="JSONLD11"></a>JSON-LD             | <https://www.w3.org/TR/2020/REC-json-ld11-20200716/>                                                                                                                                                   |
-| <a id="JSONSCHEMA202012"></a>JSON Schema | <https://json-schema.org/draft/2020-12/json-schema-core>                                                                                                                                               |
-| <a id="LDP"></a>W3C.REC-ldp-20150226     | Speicher, S., Arwe, J., and A. Malhotra, "Linked Data Platform 1.0", World Wide Web Consortium Recommendation REC-ldp-20150226, 26 February 2015, <https://www.w3.org/TR/2015/REC-ldp-20150226>.       |
-
-## Informative References
-
-|                              |                                                                                                                                                                                                 |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <a id="RFC7049"></a>RFC 7049 | Bormann, C. and P. Hoffman, "Concise Binary Object Representation (CBOR)", RFC 7049, DOI 10.17487/RFC7049,                             October 2013, <https://www.rfc-editor.org/info/rfc7049>. |
 
 ## Related Work
 
@@ -65,7 +32,7 @@ Both security consideration of [JSON-LD v1.1 section C](https://www.w3.org/TR/20
 | [NOMAD](http://nomad-lab.eu/prod/v1/staging/docs/schemas/basics.html)                                    | Custom schema language focussed on scientific data                                                                                                                                                                                                                                                                                                        |
 | [Human Cell Atlas](https://data.humancellatlas.org/metadata)                                             | Data schemas for the biology and medical domain                                                                                                                                                                                                                                                                                                           |
 | [OTTR](https://ottr.xyz/)                                                                                | Mixture of custom template and schema language. Limited toolset to convert from/to other formats.                                                                                                                                                                                                                                                         |
-| [TheWorldAvatar/ObjectGraphMapper](https://github.com/cambridge-cares/TheWorldAvatar/tree/main/core/ogm) | Class-RDF Mapping in Java via decorators                                                                                                                                                                                                                                                                                                                 |
+| [TheWorldAvatar/ObjectGraphMapper](https://github.com/cambridge-cares/TheWorldAvatar/tree/main/core/ogm) | Class-RDF Mapping in Java via decorators                                                                                                                                                                                                                                                                                                                  |
 | [Cross-Domain Interoperability Framework (CDIF)](https://zenodo.org/records/11236871)                    | CDIF is a set of implementation recommendations, based on profiles of common, domain-neutral metadata standards which are aligned to work together to support core functions required by FAIR.                                                                                                                                                            |
 | [DDI-CDI](https://ddi-cdi.github.io/ddi-cdi_v1.0-rc3/field-level-documentation/index.html)               | Cross domain meta data model between domain specific specifications and high - level specifications such as DCAT and Datacite                                                                                                                                                                                                                             |
 

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -121,7 +121,7 @@
 
 <section id="basic-concepts"><h2>Basic Concepts</h2><p>The core idea is that an [=OO-LD schema=] is always both a valid JSON Schema and a reference-able JSON-LD [=remote context=] as defined in [[JSON-LD11]] §3.1 (<em>not</em> a JSON-LD document). In this way a complete OO-LD class / schema hierarchy is consume-able by JSON Schema-only and JSON-LD-only tools while OO-LD-aware tools can provide extended features on top (e.g. UI autocomplete dropdowns for string-IRI fields based on a SPARQL backend, or SHACL shape / JSON-LD frame generation).</p>
 <aside class="example" title="A minimal OO-LD schema"><pre><code class="language-json">{
-  &quot;$schema&quot;: &quot;https://json-schema.org/draft/2020-12/schema&quot;,
+  &quot;$schema&quot;: &quot;https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json&quot;,
   &quot;$id&quot;: &quot;Minimal.schema.json&quot;,
   &quot;@context&quot;: {
     &quot;schema&quot;: &quot;http://schema.org/&quot;,

--- a/examples/Address.schema.json
+++ b/examples/Address.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json",
   "$id": "Address.schema.json",
   "x-oold-uuid": "e8536464-a654-49ee-bd44-df60424b73b1",
   "x-oold-version": "1.0.0",

--- a/examples/Minimal.schema.json
+++ b/examples/Minimal.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json",
   "$id": "Minimal.schema.json",
   "@context": {
     "schema": "http://schema.org/",

--- a/examples/Organization.schema.json
+++ b/examples/Organization.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json",
   "$id": "Organization.schema.json",
   "x-oold-uuid": "c6314242-8432-57cc-9b22-bd4e2026951f",
   "x-oold-version": "1.0.0",

--- a/examples/Person.schema.json
+++ b/examples/Person.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json",
   "$id": "Person.schema.json",
   "x-oold-uuid": "b5203131-7321-46bb-8a11-acb3d1015840",
   "x-oold-version": "1.0.0",

--- a/examples/Researcher.schema.json
+++ b/examples/Researcher.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json",
   "$id": "Researcher.schema.json",
   "x-oold-uuid": "d7425353-9543-48dd-ac33-ce5f3137a62a",
   "x-oold-version": "1.0.0",

--- a/examples/Thing.schema.json
+++ b/examples/Thing.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json",
   "$id": "Thing.schema.json",
   "x-oold-uuid": "1b4de2a0-9d3f-4c2e-9a1b-0e7c5f8a2d10",
   "x-oold-version": "1.0.0",

--- a/meta/oold-meta-schema.json
+++ b/meta/oold-meta-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://oo-ld.github.io/schema/meta/oold-meta-schema.json",
+  "$id": "https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json",
   "$dynamicAnchor": "meta",
   "title": "OO-LD dialect meta-schema",
   "$comment": "Provisional $id and OO-LD vocabulary URI - to be finalized when the canonical hosting location is decided. The OO-LD vocabulary is declared optional (false) so that generic JSON-Schema 2020-12 validators still process OO-LD schemas.",
@@ -12,7 +12,7 @@
     "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
     "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
     "https://json-schema.org/draft/2020-12/vocab/content": true,
-    "https://oo-ld.github.io/schema/vocab/oold": false
+    "https://oo-ld.github.io/oold-schema/latest/vocab/oold": false
   },
   "allOf": [
     { "$ref": "https://json-schema.org/draft/2020-12/schema" }

--- a/zensical.toml
+++ b/zensical.toml
@@ -111,3 +111,6 @@ generic = true
 
 [project.markdown_extensions.toc]
 permalink = true
+
+[project.extra.version]
+provider = "mike"


### PR DESCRIPTION
Everything (docs **and** schemas) versioned: latest by default, older versions at static `/major.minor.patch/` URLs. Addresses #67. Also folds in two review fixes (get-started uses the `Minimal` example; `reference.md` drops normative IANA/refs that live in the spec).

## How it works
- **zensical version selector** (`provider = mike`); the pinned zensical-fork of mike deploys each version to the **`gh-pages` branch**: `main` -> `dev`; a tag `vX.Y.Z` -> `/X.Y.Z/` + `latest` alias + root redirect.
- **Schemas versioned too**: `meta/` + `examples/` are staged into the site (`make stage-schemas`), so every version serves `/<ver>/meta/oold-meta-schema.json` and `/<ver>/schemas/*.schema.json`.
- **Spec-compliant** (spec/08 package versioning = version prepended, full semver). **Version stamping** at deploy rewrites `/latest/` -> `/X.Y.Z/` in the served schemas, so `/0.4.0/meta/oold-meta-schema.json` self-identifies (its `$id` is the versioned URL) and each example's `$schema` points at the same version. Source keeps the `/latest/` placeholder.
- **`--alias-type=copy`** so `/latest/meta/*.json` are real, fetchable files (a redirect alias 404s for machine schema fetches).
- Deploy moves off the artifact Pages action to `gh-pages` - which also **fixes the recurring flaky Pages publish** (matches oold-python).

## Validated locally (mike deploy, no push)
`/0.4.0/meta` `$id` = `.../0.4.0/meta/...`; `/0.4.0/schemas/*` `$schema` -> same version; `/latest/meta/oold-meta-schema.json` is a real file (copy alias). `npm run validate` 6/6, `check_spec` OK, guide builds clean.

## Required admin actions (do NOT auto-merge)
1. **Settings > Pages > Source -> "Deploy from a branch" -> `gh-pages`** (currently "GitHub Actions"). mike publishes there.
2. **Bootstrap:** after merge, the `main` push publishes `/dev/`. To create `/0.4.0/` + `/latest/` + the root redirect, push a release tag (re-push `v0.4.0`, or cut the next tag).

Related: #67 (meta-schema hosting - largely resolved here), #68 (pipeline cleanups).
