### PR TITLE
pipeline: generic macros + parse-based drift check (#68)

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -14,35 +14,89 @@ ROOT = os.path.dirname(os.path.abspath(__file__))
 # ReSpec renderer). Target-aware macros (e.g. a future ref()/term()) branch on it.
 TARGET = "docs"
 
+# Fence language inferred from the file extension for inline_file(lang="auto").
+_LANG_BY_EXT = {
+    ".json": "json", ".md": "markdown", ".yaml": "yaml", ".yml": "yaml",
+    ".py": "python", ".mjs": "javascript", ".js": "javascript",
+    ".sh": "bash", ".ttl": "turtle", ".html": "html",
+}
 
-def example(name, lang="json"):
-    """Inline an example schema from examples/<name>.schema.json as a code block."""
-    path = os.path.join(ROOT, "examples", f"{name}.schema.json")
-    with open(path, encoding="utf-8") as fh:
+
+def inline_file(path, lang="auto"):
+    """Inline any repo file as a fenced code block.
+
+    `path` is relative to the repo root (no hardcoded directory prefix). With
+    lang="auto" the fence language is inferred from the file extension.
+    """
+    with open(os.path.join(ROOT, path), encoding="utf-8") as fh:
         content = fh.read().rstrip("\n")
+    if lang == "auto":
+        lang = _LANG_BY_EXT.get(os.path.splitext(path)[1].lower(), "")
     return f"```{lang}\n{content}\n```"
 
 
+def example(name, lang="json"):
+    """Inline an example schema from examples/<name>.schema.json as a code block."""
+    return inline_file(f"examples/{name}.schema.json", lang)
+
+
+def _rows(properties, prefix):
+    """(keyword, description) rows for properties whose name starts with prefix."""
+    rows = []
+    for name, defn in (properties or {}).items():
+        if name.startswith(prefix):
+            desc = " ".join((defn.get("description") or "").split()).replace("|", "\\|")
+            rows.append((name, desc))
+    return rows
+
+
+def _keyword_table(rows):
+    lines = ["| Keyword | Description |", "| --- | --- |"]
+    lines += [f"| `{name}` | {desc} |" for name, desc in rows]
+    return "\n".join(lines)
+
+
+def _keyword_properties(schema):
+    """Keyword definitions of a schema: top-level `properties` plus any
+    `$defs/<name>/properties`. The UI meta-schema keeps its keywords under
+    $defs.keywords so the core schema can $ref just them, so a plain top-level
+    scan would miss them."""
+    props = dict(schema.get("properties") or {})
+    for defn in (schema.get("$defs") or {}).values():
+        if isinstance(defn, dict):
+            props.update(defn.get("properties") or {})
+    return props
+
+
+def render_schema(path, prefix="x-"):
+    """Render the extension-keyword table for one schema file (repo-relative).
+
+    Collects keywords from the top-level `properties` and from
+    `$defs/*/properties`, keeping those whose name starts with `prefix`
+    (default "x-", so x-oold-*, x-oold-ui-*, x-enum-*, ... are all included).
+    """
+    with open(os.path.join(ROOT, path), encoding="utf-8") as fh:
+        schema = json.load(fh)
+    return _keyword_table(_rows(_keyword_properties(schema), prefix))
+
+
 def vocabulary():
-    """Render the x-oold-* keyword table from every meta/*.json (single source)."""
+    """Render the core x-oold-* keyword table from every meta/*.json top-level
+    `properties` (single source). Dialect keywords kept under $defs (e.g. the UI
+    meta-schema's x-oold-ui-*) get their own section via render_schema, so they
+    are not duplicated here."""
     meta_dir = os.path.join(ROOT, "meta")
     rows = []
     for fname in sorted(os.listdir(meta_dir)):
         if not fname.endswith(".json"):
             continue
         with open(os.path.join(meta_dir, fname), encoding="utf-8") as fh:
-            schema = json.load(fh)
-        for name, defn in (schema.get("properties") or {}).items():
-            if name.startswith("x-oold-"):
-                desc = " ".join((defn.get("description") or "").split()).replace("|", "\\|")
-                rows.append((name, desc))
-    lines = ["| Keyword | Description |", "| --- | --- |"]
-    lines += [f"| `{name}` | {desc} |" for name, desc in rows]
-    return "\n".join(lines)
+            rows += _rows(json.load(fh).get("properties"), "x-oold-")
+    return _keyword_table(rows)
 
 
 # Macros reused across the project; the /spec renderer registers the same set.
-SHARED_MACROS = [example, vocabulary]
+SHARED_MACROS = [example, inline_file, render_schema, vocabulary]
 
 
 def define_env(env):

--- a/scripts/check_spec.py
+++ b/scripts/check_spec.py
@@ -16,22 +16,37 @@ import spec_config as cfg  # noqa: E402
 
 html = open(os.path.join(ROOT, "docs", "spec", "index.html"), encoding="utf-8").read()
 
-# ReSpec resolves these bibliography keys from its built-in database; anything
-# else must be declared in localBiblio.
+# ReSpec resolves these bibliography keys from its built-in database (SpecRef);
+# that set is external to this repo, so it stays a small curated list. Anything
+# not here and not in localBiblio must be a typo.
 KNOWN_BIBLIO = {"RFC2119", "RFC7386", "RFC3986", "RFC6906", "JSON-LD11"}
 
-EXPECTED_IDS = sorted([
-    "abstract", "basic-concepts", "compatibility", "composition", "conformance",
-    "design-goals", "expressiveness", "extensions", "iana", "identification",
-    "identification-versioning", "identity", "index", "interoperability",
-    "introduction", "jsonld-extensions", "jsonschema-extensions",
-    "localizing-instance-values", "localizing-schema-annotations",
-    "merge-and-override-model", "merging-remote-contexts", "meta-schema",
-    "multi-mapping", "multilanguage", "ontology-class-iri", "processing-mode",
-    "range-of-properties", "referencing-schema", "reverse-properties",
-    "schema-instances", "security", "semantic-type", "sotd", "terminology",
-    "ui-generation", "versioning", "why-x-oold-ref",
-])
+SECTIONS_DIR = os.path.join(ROOT, "spec", "sections")
+# {#id} attribute on any ATX heading (only these become <section id="..."> ids).
+HEADING_ID = re.compile(r'^\s*#{2,6}\s+.*\{[^}]*#([A-Za-z0-9_-]+)[^}]*\}\s*$', re.M)
+
+
+def expected_ids():
+    """Section ids the generated HTML must contain, derived from the source.
+
+    Every {#id} on a heading in spec/sections/*.md, plus the ids that come from
+    the config rather than a heading (headingless abstract/sotd, and the
+    generated terminology/index sections). Parsing the source instead of a
+    hand-maintained list means new anchors need no bookkeeping here.
+    """
+    ids = set()
+    for entry in cfg.SECTIONS:
+        if entry.get("file"):
+            src = open(os.path.join(SECTIONS_DIR, entry["file"]), encoding="utf-8").read()
+            ids.update(HEADING_ID.findall(src))
+            if entry.get("headingless") and entry.get("id"):
+                ids.add(entry["id"])
+        elif entry.get("generate"):
+            ids.add(entry["generate"])  # "terminology" / "index"
+    return ids
+
+
+EXPECTED_IDS = sorted(expected_ids())
 
 errors = []
 
@@ -63,7 +78,7 @@ extra = [i for i in section_ids if i not in EXPECTED_IDS]
 if missing:
     errors.append("missing expected section ids: " + ", ".join(missing))
 if extra:
-    errors.append("unexpected section ids: " + ", ".join(extra) + " (update EXPECTED_IDS if intentional)")
+    errors.append("unexpected section ids: " + ", ".join(extra) + " (no matching {#id} in spec/sections/*.md or config)")
 
 if errors:
     print("spec check FAILED:", file=sys.stderr)


### PR DESCRIPTION
Addresses the enabling items from #68 (spec pipeline follow-ups from the #63 review).

**macros.py**
- `inline_file(path, lang='auto')` - generic include primitive, no hardcoded `examples/` prefix, language inferred from extension. `example()` is now a thin wrapper over it.
- `render_schema(path)` - render one meta-schema's `x-oold-*` keyword table (used next for the UI vocabulary in #62). Shares `_keyword_rows`/`_keyword_table` with `vocabulary()` - one renderer, not a bespoke second one.

**scripts/check_spec.py**
- Derive the expected section-id set from the source (`{#id}` headings in `spec/sections/*.md` plus headingless/generated ids) instead of the hand-maintained `EXPECTED_IDS` list. New anchors (e.g. from #62/#12) now need no bookkeeping here. `KNOWN_BIBLIO` stays a small curated list because ReSpec's SpecRef keys are external to the repo.

Deferred within #68: dropping the numeric filename prefixes (`00-`, `09-`, ...) - it would rename files that the in-flight #62/#12 branches edit; better done after those land. `mistune -> wenmode` and glossary/bibliography also remain for a later pass.

**Verification**: `docs/spec/index.html` re-renders byte-identical (behavior-preserving), `check_spec.py` OK (37 sections, 11 aliases), `npm run validate` 6/6, `zensical build` clean.