### PR TITLE
fix: broken spec header links (missing version segment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The site covers the concepts and specification in an orientation-style guide wit
 - [Guide](https://OO-LD.github.io/oold-schema/guide/) - basic concepts, composition, schema instances, identification & versioning, extensions, and the meta-schema.
 - [Use Cases](https://OO-LD.github.io/oold-schema/use-cases/), [Mappings](https://OO-LD.github.io/oold-schema/mappings/), [Tooling](https://OO-LD.github.io/oold-schema/tooling/), and [Reference](https://OO-LD.github.io/oold-schema/reference/).
 
-The normative, W3C-style **[Specification](https://OO-LD.github.io/oold-schema/spec/)** (rendered with [ReSpec](https://respec.org/)) accompanies the guide: the guide is for learning, the specification is for conformance and citation.
+The normative, W3C-style **[Specification](https://oo-ld.github.io/oold-schema/latest/spec/)** (rendered with [ReSpec](https://respec.org/)) accompanies the guide: the guide is for learning, the specification is for conformance and citation.
 
 ## Repository contents
 

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -32,8 +32,8 @@
     "repoURL": "https://github.com/OO-LD/oold-schema",
     "branch": "main"
   },
-  "latestVersion": "https://OO-LD.github.io/oold-schema/spec/",
-  "edDraftURI": "https://OO-LD.github.io/oold-schema/spec/",
+  "latestVersion": "https://oo-ld.github.io/oold-schema/latest/spec/",
+  "edDraftURI": "https://oo-ld.github.io/oold-schema/dev/spec/",
   "logos": [
     {
       "src": "../assets/OO-LD_logo.jpg",

--- a/scripts/spec_config.py
+++ b/scripts/spec_config.py
@@ -15,8 +15,8 @@ RESPEC = {
         {"name": "Andreas Räder", "company": "OO-LD", "companyURL": "https://github.com/OO-LD"},
     ],
     "github": {"repoURL": "https://github.com/OO-LD/oold-schema", "branch": "main"},
-    "latestVersion": "https://OO-LD.github.io/oold-schema/spec/",
-    "edDraftURI": "https://OO-LD.github.io/oold-schema/spec/",
+    "latestVersion": "https://oo-ld.github.io/oold-schema/latest/spec/",
+    "edDraftURI": "https://oo-ld.github.io/oold-schema/dev/spec/",
     "logos": [
         {
             "src": "../assets/OO-LD_logo.jpg",


### PR DESCRIPTION
The ReSpec header links ("Latest published version" / "Editor's draft") and the README Specification link pointed at `https://oo-ld.github.io/oold-schema/spec/` - **no version segment** - which 404s, since the spec is served at `/oold-schema/<version>/spec/`.

- `latestVersion` -> `https://oo-ld.github.io/oold-schema/latest/spec/` (stable release)
- `edDraftURI` -> `https://oo-ld.github.io/oold-schema/dev/spec/` (main / editor's draft)
- README Specification link -> `/latest/spec/`

Regenerated `docs/spec/index.html`; `check_spec` OK. Fixes the broken `/oold-schema/spec/` link; lands on `/dev/` at next merge to main.