### PR TITLE
docs: weave the LLM Wiki motivation into the guide

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -12,6 +12,7 @@ What makes OO-LD different from other approaches that unify structure and semant
 - OO-LD schemas are compatible with LLM APIs
 - OO-LD schemas can be used as function (dataclasses) and API signatures (OpenAPI)
 - OO-LD schemas can be used to define graphical user interfaces, in particular forms
+- OO-LD schemas turn a wiki or document store into a compounding, SPARQL-queryable knowledge base - the ["LLM Wiki" pattern](use-cases.md#structured-knowledge-bases-the-llm-wiki-pattern)
 
 ![OSL Technologie Stack](https://opensemantic.world/wiki/Special:Redirect/file/OSW95a74be1e22d4b6e9e4f836127d5915a.drawio.svg)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9,6 +9,7 @@ This page collects informative reference material - the package registry, discus
 ## Discussion
 
 - In the context of YAML-LD: <https://github.com/w3c/yaml-ld/issues/19>
+- The "LLM Wiki" pattern (persistent, LLM-maintained knowledge bases), and OO-LD's structured take on it: <https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f>
 
 ## Related Work
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -120,3 +120,11 @@ maps to the following OpenAPI 3.0 document, one Schema Object per class (the `$i
   }
 }
 ```
+
+## Structured knowledge bases (the "LLM Wiki" pattern)
+
+An LLM-maintained knowledge base only *compounds* if what accumulates is structured. Unqualified links and free text do not scale - a personal wiki decays to prose and dead links within a couple of years, a team or corporate one faster - because every question forces the model to re-read and re-derive. What accumulates value is typed, queryable entities.
+
+OO-LD gives each entry a schema-defined structured payload alongside its prose. Because an OO-LD schema is at once a JSON Schema and a JSON-LD context, the *same* schema (a) generates the human edit form, (b) constrains LLM structured-output extraction, and (c) yields an RDF knowledge graph queryable with SPARQL across all entries - so "find contradictions, orphans or duplicates" becomes a graph query rather than a re-read.
+
+The workflow this enables, and where current research sits, is the ingest loop: take an unstructured knowledge chunk, select the schema(s) that represent it, then fill them correctly *and* deduplicate against entities that already exist. That last step - entity resolution against a live graph - is the hard part. [OpenSemanticLab](https://github.com/OpenSemanticLab) is the reference implementation of this pattern; the broader idea is discussed in the [Reference](reference.md#discussion) pointers.


### PR DESCRIPTION
Adds the "LLM Wiki" motivation (persistent, structured, LLM-maintained knowledge bases) to the guide, prompted by the discussion on Karpathy's LLM Wiki gist.

- **`docs/use-cases.md`**: new section "Structured knowledge bases (the LLM Wiki pattern)" - unstructured content/links don't compound; OO-LD gives each entry a schema-defined structured payload so one schema drives forms + LLM structured output + an RDF/SPARQL knowledge graph; the open ingest loop (select schema -> fill -> dedup). Points to OpenSemanticLab as the reference implementation.
- **`docs/introduction.md`**: capstone "Why OO-LD?" bullet linking to that section.
- **`docs/reference.md`**: Discussion link to the "LLM Wiki" gist thread.

Guide-only; the normative spec is untouched.