### PR TITLE
ci: serialize gh-pages deploys (fix release/dev push race)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,6 @@ env:
   ZENSICAL_VERSION: "0.0.46"
   MIKE_SPEC: "git+https://github.com/squidfunk/mike.git@2.2.0+zensical-0.1.0"
 
-concurrency:
-  group: pages-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -49,6 +45,13 @@ jobs:
   deploy:
     needs: validate
     runs-on: ubuntu-latest
+    # Serialize ALL deploys on one group so concurrent runs never race to push
+    # gh-pages. A per-ref group let a main push (-> dev) and a tag push (-> release)
+    # deploy simultaneously, and one lost the fast-forward (seen releasing v0.5.0).
+    # Queue rather than cancel so no deploy is dropped.
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
     permissions:
       contents: write  # mike pushes to gh-pages
     steps:


### PR DESCRIPTION
Releasing v0.5.0 surfaced a race: pushing `main` (deploy -> `dev`) and the `v0.5.0` tag (deploy -> release) near-simultaneously launched two deploy jobs that both push `gh-pages`, and the tag deploy lost the fast-forward (`! [rejected] gh-pages -> gh-pages (fetch first)`). It only recovered on a manual re-run.

Cause: the `concurrency` group was keyed per-ref (`pages-${{ github.ref }}`), so `main` and a tag are different groups and don't serialize.

Fix: move concurrency to the `deploy` job with a constant group `pages-deploy` (`cancel-in-progress: false`), so every deploy serializes on `gh-pages` (queued, never dropped) while PR/validate runs remain unthrottled. Prevents the same race at the v1.0 release.