### PR TITLE
docs/spec: JSON-canonical notation + JSON/YAML example tabs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,14 +69,15 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Build only (pull request)
         if: github.event_name != 'push'
-        run: uvx zensical@${{ env.ZENSICAL_VERSION }} build --clean
+        # --with pyyaml: the shared macros render JSON / "View as YAML" example tabs.
+        run: uvx --with pyyaml==6.0.2 zensical@${{ env.ZENSICAL_VERSION }} build --clean
       - name: Publish dev (push to main)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           # Stamp the served schema copies with this version id so they self-identify
           # (the source keeps the /latest/ placeholder; staged copies are gitignored).
           sed -i 's#/oold-schema/latest/#/oold-schema/dev/#g' docs/meta/*.json docs/schemas/*.json
-          uvx --from "$MIKE_SPEC" mike deploy --push dev
+          uvx --with pyyaml==6.0.2 --from "$MIKE_SPEC" mike deploy --push dev
       - name: Publish release (tag vX.Y.Z)
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -86,6 +87,6 @@ jobs:
           sed -i "s#/oold-schema/latest/#/oold-schema/$ver/#g" docs/meta/*.json docs/schemas/*.json
           # --alias-type=copy so /latest/ is a real directory (its schema JSON is
           # fetchable; a redirect alias would 404 for machine schema references).
-          MIKE="uvx --from $MIKE_SPEC mike"
+          MIKE="uvx --with pyyaml==6.0.2 --from $MIKE_SPEC mike"
           $MIKE deploy --push --alias-type=copy --update-aliases "$ver" latest
           $MIKE set-default --push latest

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 # Pin zensical to match .github/workflows/main.yml for reproducible
 # documentation builds. Override on the command line, e.g. `make docs ZENSICAL_VERSION=0.0.47`.
 ZENSICAL_VERSION ?= 0.0.46
-ZENSICAL := uvx zensical@$(ZENSICAL_VERSION)
+# --with pyyaml==6.0.2 so the shared macros (macros.py) can import yaml to render the
+# JSON / "View as YAML" example tabs during the docs build.
+ZENSICAL := uvx --with pyyaml==6.0.2 zensical@$(ZENSICAL_VERSION)
 
 # The spec renderer runs on Python via uv (like zensical); its dependencies are
 # pinned inline in the script (PEP 723), so `uv run` needs no extra flags and the

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -12,6 +12,9 @@ The core idea of OO-LD is that a single document is at once a valid **JSON Schem
 - The `@context` part maps the `name` property to the semantic term `schema:name`, describing its **meaning**.
 - `$id` gives the schema a stable identity and `$schema` declares the OO-LD dialect (the meta-schema).
 
+!!! note "JSON or YAML?"
+    JSON is the canonical notation for OO-LD. YAML is an equivalent, more human-friendly rendering as long as it stays within the JSON-compatible subset (no anchors, tags, or implicit typing surprises), so every example here has a **"View as YAML"** tab. See the specification's [Notation](spec/index.html#notation) section for the normative rule.
+
 ## Step 2 - Try it in the playground
 
 You can explore this exact example - validation, UI generation, and RDF output - in the [interactive playground](https://oo-ld.github.io/playground/).

--- a/docs/guide/schema-instances.md
+++ b/docs/guide/schema-instances.md
@@ -5,9 +5,11 @@ An OO-LD instance is a JSON document that conforms to an OO-LD schema. It refere
 - `@context` - the schema URL, loaded as a JSON-LD remote context. This is what makes the instance a JSON-LD document.
 - `$schema` - the schema URL, identifying the schema the instance validates against.
 
-```yaml
-"@context": https://example.org/my-package/1.0.0/Person.schema.json
-$schema: https://example.org/my-package/1.0.0/Person.schema.json
+```json
+{
+  "@context": "https://example.org/my-package/1.0.0/Person.schema.json",
+  "$schema": "https://example.org/my-package/1.0.0/Person.schema.json"
+}
 ```
 
 An instance can also carry its own identity as an `@id` (usually exposed through an aliased `id` property), and on export its semantic `@type` is materialized from the schema's `x-oold-instance-rdf-type`.

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -2,6 +2,9 @@
 
 OO-LD can act as a bridge between several existing schema languages and data models. This page shows how selected formats map to OO-LD schemas and instances.
 
+!!! note "Notation on this page"
+    Unlike the rest of the documentation, where JSON is the canonical notation (see the specification's [Notation](spec/index.html#notation) section), the examples here are shown in **YAML**. Several of the compared formats (LinkML, NOMAD, dlite, yml2vocab) are natively YAML, so the OO-LD side is shown in YAML too for a direct, line-by-line comparison.
+
 ## Asset Administration Shell
 
 Asset Administration Shell combines schema and data in a single documents. Semantics are introduced by annotations keywords.

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -74,6 +74,28 @@
       "publisher": "IETF",
       "status": "Best Current Practice"
     },
+    "RFC8259": {
+      "title": "The JavaScript Object Notation (JSON) Data Interchange Format",
+      "href": "https://www.rfc-editor.org/rfc/rfc8259",
+      "authors": [
+        "T. Bray"
+      ],
+      "date": "December 2017",
+      "publisher": "IETF",
+      "status": "Internet Standard"
+    },
+    "RFC8785": {
+      "title": "JSON Canonicalization Scheme (JCS)",
+      "href": "https://www.rfc-editor.org/rfc/rfc8785",
+      "authors": [
+        "A. Rundgren",
+        "B. Jordan",
+        "S. Erdtman"
+      ],
+      "date": "June 2020",
+      "publisher": "IETF",
+      "status": "Informational"
+    },
     "RFC3986": {
       "title": "Uniform Resource Identifier (URI): Generic Syntax",
       "href": "https://www.rfc-editor.org/rfc/rfc3986",
@@ -136,6 +158,27 @@
     const schedule = () => setTimeout(runMermaid, 500);  // let ReSpec finish rearranging first
     if (document.readyState === "complete") schedule(); else window.addEventListener("load", schedule);
   </script>
+  <style>
+    .ex-tabs { margin: 1em 0; }
+    .ex-tablist { display: flex; gap: .25rem; border-bottom: 1px solid #ccc; margin-bottom: .5em; }
+    .ex-tab { border: 0; background: none; padding: .3em .8em; cursor: pointer; font: inherit; color: #555; border-bottom: 2px solid transparent; }
+    .ex-tab[aria-selected="true"] { color: #005a9c; border-bottom-color: #005a9c; font-weight: 600; }
+    .ex-panel[hidden] { display: none; }
+  </style>
+  <script>
+    // Toggle the JSON / YAML example tabs (event delegation; runs regardless of ReSpec).
+    document.addEventListener("click", function (e) {
+      var tab = e.target.closest(".ex-tab");
+      if (!tab) return;
+      var group = tab.closest(".ex-tabs");
+      group.querySelectorAll(".ex-tab").forEach(function (b) {
+        b.setAttribute("aria-selected", b === tab ? "true" : "false");
+      });
+      group.querySelectorAll(".ex-panel").forEach(function (p) {
+        p.hidden = (p.id !== tab.dataset.panel);
+      });
+    });
+  </script>
 </head>
 <body>
 <p class="copyright">Copyright &copy; the OO-LD contributors. This document is made available under the <a rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal</a> Public Domain Dedication; W3C liability, trademark and document-license rules do <strong>not</strong> apply.</p>
@@ -167,7 +210,9 @@
 <p>OO-LD inverts the order. Because it is JSON Schema first, a term exists as a plain structural property with no semantics attached; an author MAY leave it unmapped, map it to a single IRI, or map it to several concurrent IRIs (see <a href="#multi-mapping"></a> and <a href="#synonyms"></a>). An unmapped term produces no triples under JSON-LD expansion; to prevent such terms from being dropped silently, an author MAY declare <code>@vocab</code> in the <code>@context</code>, which maps every otherwise-unmapped term to a default (local) namespace so it still round-trips to RDF under a provisional IRI until a curated mapping is assigned. Any data can be serialized as JSON and therefore described by a schema, so the structural model - validation, forms, code generation, transport - is always available, and semantics can be added later, incrementally, one term at a time. The floor on this deferral is identity, not zero: graph-shaped data still needs identifiers for its links (carried by IRI-valued properties and <a href="#range-of-properties"></a>), but the vocabulary and meaning of each field can be deferred without blocking any of the structural uses. This is the boundary to RDF/SHACL: they cannot withhold semantic commitment, OO-LD can.</p></section></section>
 
 <section id="conformance"><h2>Conformance</h2><p>As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.</p>
-<p>The key words <em class="rfc2119">MUST</em>, <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">REQUIRED</em>, <em class="rfc2119">SHALL</em>, <em class="rfc2119">SHALL NOT</em>, <em class="rfc2119">SHOULD</em>, <em class="rfc2119">SHOULD NOT</em>, <em class="rfc2119">RECOMMENDED</em>, <em class="rfc2119">MAY</em>, and <em class="rfc2119">OPTIONAL</em> in this document are to be interpreted as described in [[!RFC2119]].</p></section>
+<p>The key words <em class="rfc2119">MUST</em>, <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">REQUIRED</em>, <em class="rfc2119">SHALL</em>, <em class="rfc2119">SHALL NOT</em>, <em class="rfc2119">SHOULD</em>, <em class="rfc2119">SHOULD NOT</em>, <em class="rfc2119">RECOMMENDED</em>, <em class="rfc2119">MAY</em>, and <em class="rfc2119">OPTIONAL</em> in this document are to be interpreted as described in [[!RFC2119]].</p><section id="notation"><h3>Notation</h3><p>The normative data model of OO-LD is the JSON data model shared by [[JSONSCHEMA]] and [[JSON-LD11]]. JSON ([[RFC8259]]) is the canonical serialization: a conforming OO-LD schema or instance <em class="rfc2119">MUST</em> be interchangeable as JSON, and the canonical form used for identity and integrity (for example content-hashing a versioned schema) is its JSON Canonicalization Scheme ([[RFC8785]]) serialization.</p>
+<p>A document <em class="rfc2119">MAY</em> additionally be authored or served as YAML, provided it stays within the JSON-compatible subset of <a href="https://yaml.org/spec/1.2.2/">YAML 1.2</a>: no tags, anchors, aliases, or merge keys; a single document; and no implicit typing beyond what JSON expresses. Within this subset - the same profile adopted by <a href="https://github.com/w3c/yaml-ld">YAML-LD</a> - a YAML document maps one-to-one onto the JSON data model and converts to the canonical JSON without loss. YAML outside this subset is NOT a conforming OO-LD serialization.</p>
+<p>Authors using YAML should be aware that YAML comments and implicit type coercions (for example the strings <code>NO</code> or <code>1.10</code> read as a boolean or a truncated number by some parsers) do not survive conversion to the canonical JSON; the JSON form is authoritative. Examples in this specification are shown as JSON, with an equivalent YAML rendering available under &quot;View as YAML&quot;.</p></section></section>
 
 <section id="terminology">
   <h2>Terminology</h2>
@@ -189,7 +234,12 @@
 </section>
 
 <section id="basic-concepts"><h2>Basic Concepts</h2><p>The core idea is that an [=OO-LD schema=] is always both a valid JSON Schema and a reference-able JSON-LD [=remote context=] as defined in [[JSON-LD11]] §3.1 (<em>not</em> a JSON-LD document). In this way a complete OO-LD class / schema hierarchy is consume-able by JSON Schema-only and JSON-LD-only tools while OO-LD-aware tools can provide extended features on top (e.g. UI autocomplete dropdowns for string-IRI fields based on a SPARQL backend, or SHACL shape / JSON-LD frame generation).</p>
-<aside class="example" title="A minimal OO-LD schema"><pre><code class="language-json">{
+<aside class="example" title="A minimal OO-LD schema"><div class="ex-tabs">
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex1j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex1y">View as YAML</button></div>
+
+<div class="ex-panel" id="ex1j" role="tabpanel">
+
+<pre><code class="language-json">{
   &quot;$schema&quot;: &quot;https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json&quot;,
   &quot;$id&quot;: &quot;Minimal.schema.json&quot;,
   &quot;@context&quot;: {
@@ -202,7 +252,26 @@
     &quot;name&quot;: { &quot;type&quot;: &quot;string&quot;, &quot;description&quot;: &quot;Name of the thing&quot; }
   }
 }
-</code></pre></aside>
+</code></pre>
+</div>
+
+<div class="ex-panel" id="ex1y" role="tabpanel" hidden>
+
+<pre><code class="language-yaml">$schema: https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json
+$id: Minimal.schema.json
+'@context':
+  schema: http://schema.org/
+  name: schema:name
+title: Minimal
+type: object
+properties:
+  name:
+    type: string
+    description: Name of the thing
+</code></pre>
+</div>
+
+</div></aside>
 <p>There is an asymmetry between how schemas and instances are consumed:</p>
 <ul>
 <li>An [=OO-LD schema=] is consumed as a JSON-LD [=remote context=] (referenced by its URL from an instance's <code>@context</code>), never as a JSON-LD document. OO-LD schema documents <em class="rfc2119">MUST NOT</em> be interpreted as JSON-LD documents, because that would apply the schema's own <code>@context</code> to the schema itself and produce incorrect triples.</li>
@@ -959,6 +1028,11 @@ intersections (<code>allOf</code>) and inline constraints can be combined to des
 <p>The text-valued keywords have a <code>x-oold-multilang-*</code> variant carrying a BCP-47 language map, mirroring <code>x-oold-multilang-title</code> (see <a href="#localizing-schema-annotations"></a>): <code>x-oold-multilang-ui-hint</code> and <code>x-oold-multilang-ui-enum-titles</code>.</p>
 <p>For enum code generation OO-LD keeps the established <code>x-enum-varnames</code> (identifier-safe names aligned with <code>enum</code>) and its companion <code>x-enum-descriptions</code>; these are widely supported vendor extensions (OpenAPI Generator; NSwag's <code>x-enumNames</code>) and are distinct from the human display labels in <code>x-oold-ui-enum-titles</code>.</p>
 <p><code>x-oold-ui-default-property</code> replaces the json-editor <code>defaultProperties</code> array (which listed the optional properties shown initially). That array is <em>extend-only</em> under composition: because composed schemas merge the arrays, a derived schema can add a default property but cannot switch one off. A per-property boolean is <em>overridable</em> - it resolves most-derived-wins (see <a href="#merge-and-override-model"></a>), so a derived schema sets it to <code>false</code> to hide a property a base schema showed. For the same reason <code>x-oold-reverse-default-properties</code> is deprecated in favour of <code>x-oold-ui-default-property</code> on the reverse property.</p></section><section id="widget-hints"><h5>Widget hints: <code>format</code> vs <code>x-oold-ui-widget</code></h5><p><code>format</code> carries the widget hint when its value is a registered JSON Schema 2020-12 format (<code>date</code>, <code>date-time</code>, <code>time</code>, <code>duration</code>, <code>email</code>, <code>uri</code>, <code>iri</code>, <code>uuid</code>, ...); a validator may check it and a form generator picks the matching input. Values that are not registered formats (<code>table</code>, <code>tabs</code>, <code>grid</code>, <code>autocomplete</code>, <code>textarea</code>, <code>checkbox</code>, <code>markdown</code>, <code>color</code>, ...) are widget-only and go in <code>x-oold-ui-widget</code>, leaving <code>format</code> for validation semantics.</p></section><section id="validator-vs-widget" class="informative"><h5>Validator vs. form widget</h5><p>A modern JSON Schema 2020-12 toolchain - ajv, the json-editor / jedison built-in validator, Hyperjump, Pydantic v2, OpenAPI 3.1 - honours <code>const</code> and keywords placed alongside <code>$ref</code>, so OO-LD's composition constructs validate as written; the older assumption that such tooling silently drops them does not hold for these validators. A narrower caveat concerns UI generation rather than validation: a form generator's <em>widget rendering</em> of a keyword may differ from what its <em>validator</em> enforces - for example json-editor validates <code>const</code> but does not necessarily render the field as a fixed value. A consumer restricted to a Draft-4-only JSON Schema processor remains the exception, since keywords adjacent to <code>$ref</code> and <code>const</code> are only guaranteed from later drafts.</p></section><section id="ui-delivery"><h5>Delivery: inline or overlay</h5><p>UI keywords may be embedded in the schema (inline):</p>
+<div class="ex-tabs">
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex2j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex2y">View as YAML</button></div>
+
+<div class="ex-panel" id="ex2j" role="tabpanel">
+
 <pre><code class="language-json">{
   &quot;$schema&quot;: &quot;https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json&quot;,
   &quot;$id&quot;: &quot;UiAnnotations.schema.json&quot;,
@@ -1019,7 +1093,95 @@ intersections (<code>allOf</code>) and inline constraints can be combined to des
   }
 }
 </code></pre>
+</div>
+
+<div class="ex-panel" id="ex2y" role="tabpanel" hidden>
+
+<pre><code class="language-yaml">$schema: https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json
+$id: UiAnnotations.schema.json
+'@context':
+- '@version': 1.1
+  schema: https://schema.org/
+  name: schema:name
+  role: schema:jobTitle
+  homepage:
+    '@id': schema:url
+    '@type': '@id'
+  notes: schema:comment
+  internal_id: schema:identifier
+x-oold-uuid: b1e7a0c2-2d4f-4a1e-9c3a-7f0e5d2b6a11
+title: Researcher
+x-oold-multilang-title:
+  en: Researcher
+  de: Forschende Person
+x-oold-iri: schema:Person
+type: object
+properties:
+  name:
+    type: string
+    title: Name
+    x-oold-ui-default-property: true
+    x-oold-ui-property-order: 1
+    x-oold-ui-property-group: General
+    x-oold-ui-hint: Full name
+    x-oold-multilang-ui-hint:
+      en: Full name
+      de: Vollständiger Name
+  role:
+    type: string
+    title: Role
+    enum:
+    - pi
+    - postdoc
+    - phd
+    x-enum-varnames:
+    - PrincipalInvestigator
+    - PostDoc
+    - PhDStudent
+    x-enum-descriptions:
+    - Leads the project
+    - Holds a doctorate
+    - Doctoral candidate
+    x-oold-ui-enum-titles:
+    - Principal investigator
+    - Postdoc
+    - PhD student
+    x-oold-multilang-ui-enum-titles:
+      en:
+      - Principal investigator
+      - Postdoc
+      - PhD student
+      de:
+      - Projektleitung
+      - Postdoc
+      - Doktorand
+    x-oold-ui-property-order: 2
+    x-oold-ui-property-group: General
+  homepage:
+    type: string
+    title: Homepage
+    format: uri
+    x-oold-ui-property-group: Contact
+  notes:
+    type: string
+    title: Notes
+    x-oold-ui-widget: markdown
+    x-oold-ui-property-group: Contact
+  internal_id:
+    type: string
+    title: Internal id
+    x-oold-ui-form-hidden: true
+</code></pre>
+</div>
+
+</div>
+
 <p>or applied by an <em>overlay</em> - a separate document that patches a schema without editing it, following the <a href="https://spec.openapis.org/overlay/latest.html">OpenAPI Overlay 1.1.0</a> model. Overlays are a general schema-patching mechanism: the <code>update</code> actions can inject any keywords (semantics, constraints or presentation), and applying <code>x-oold-ui-*</code> annotations is one use case - useful when the schema is generated or owned elsewhere, or when one schema needs different presentation in different contexts. An overlay lists <code>actions</code>, each selecting nodes with an <a href="https://www.rfc-editor.org/rfc/rfc9535">RFC 9535 JSONPath</a> <code>target</code> and merging keys via <code>update</code> (or removing them via <code>remove</code>):</p>
+<div class="ex-tabs">
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex3j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex3y">View as YAML</button></div>
+
+<div class="ex-panel" id="ex3j" role="tabpanel">
+
 <pre><code class="language-json">{
   &quot;overlay&quot;: &quot;1.0.0&quot;,
   &quot;info&quot;: {
@@ -1048,6 +1210,37 @@ intersections (<code>allOf</code>) and inline constraints can be combined to des
   ]
 }
 </code></pre>
+</div>
+
+<div class="ex-panel" id="ex3y" role="tabpanel" hidden>
+
+<pre><code class="language-yaml">overlay: 1.0.0
+info:
+  title: Researcher admin overlay
+  version: 1.0.0
+  description: Applies presentation-only x-oold-ui-* keywords to Researcher without editing the schema.
+    An overlay is a general schema-patching mechanism (OpenAPI Overlay 1.1.0); UI annotation is one use
+    case.
+extends: ./UiAnnotations.schema.json
+actions:
+- target: $.properties.internal_id
+  description: Show the internal id for admins.
+  update:
+    x-oold-ui-form-hidden: false
+- target: $.properties.notes
+  description: Render notes as a plain textarea instead of markdown.
+  update:
+    x-oold-ui-widget: textarea
+- target: $.properties.role
+  description: Drop the render-time grouping for a flat admin form.
+  remove: false
+  update:
+    x-oold-ui-property-group: Identity
+</code></pre>
+</div>
+
+</div>
+
 <p>The vendor keywords are documented by their respective projects: jedison's <code>x-jedison-*</code> (see <a href="https://github.com/germanbisurgi/jedison/issues/58">germanbisurgi/jedison#58</a> and the overlay proposal <a href="https://github.com/germanbisurgi/jedison/issues/59">#59</a>) and, for schemas coming from OpenSemanticLab, the server-side <code>x-osl-*</code> keywords. Migrating a legacy OpenSemanticWorld schema to these keywords is covered in the <a href="../migration/from-legacy-osw/">migration guide</a>.</p></section></section></section><section id="semantic-delivery"><h3>Semantic delivery</h3><p>An OO-LD schema carries its semantics in the top-level <code>@context</code> and, for the RDF type of instances, in <code>x-oold-instance-rdf-type</code>. How those reach a consumer depends only on which keywords the consumer tolerates. The native form is preferred; the alternatives below are mechanically generated from it, so the OO-LD document remains the single source and every form yields the same RDF.</p>
 <ul>
 <li>A consumer that accepts arbitrary JSON Schema keywords <em class="rfc2119">SHOULD</em> receive the native form unchanged. This covers plain JSON Schema 2020-12 validators, OpenAPI 3.1, and - because they place no restriction on <code>@context</code> - Model Context Protocol tool schemas (<code>inputSchema</code> / <code>outputSchema</code>) as well as LLM tool-use and structured-output APIs, which carry the context through and can use it as grounding.</li>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -308,22 +308,49 @@ classDiagram
 
 <section id="composition"><h2>Composition</h2><p>Composition is how an [=OO-LD schema=] incorporates multiple independent schemas, each contributing its own properties and JSON-LD term mappings, without requiring a shared parent class. This lets you build complex types by assembling reusable building blocks - for example, attaching a geolocation schema and a contact schema to a single resource type. The rules below govern how the resulting <code>@context</code> is assembled automatically, so that no post-processing step is needed.</p>
 <p>It <em class="rfc2119">MUST NOT</em> be required to further process an OO-LD schema document in order to interpret it as a JSON-LD context. This implies that all occurrences of <code>$ref</code> in the schema are reflected in the JSON-LD context. <code>$ref</code> within properties of <code>type: object</code> <em class="rfc2119">MUST</em> be listed as a scoped JSON-LD context. <code>$ref</code> within all other property types and at the root level of the OO-LD schema <em class="rfc2119">MUST</em> be listed at the root level of the JSON-LD context. In case of multiple <code>$ref</code> within <code>allOf</code> the corresponding remote contexts are merged into an array-valued <code>@context</code> (see <a href="#merging-remote-contexts"></a>). For <code>oneOf</code> / <code>anyOf</code> this requires care to avoid conflicts. At any time the importing OO-LD schema <em class="rfc2119">MAY</em> define its own or override the imported JSON-LD context.</p>
-<aside class="example" title="Reflecting each `$ref` into the `@context`"><pre><code class="language-yaml">&quot;@context&quot;:
-  - B.schema.json
-  - P1.schema.json
-  - p1:
-    &quot;@context&quot;: P1.schema.json
-  - p2:
-    &quot;@context&quot;: 
-      - P2a.schema.json
-      - P2b.schema.json
-  - p3:
-    &quot;@context&quot;:
+<aside class="example" title="Reflecting each `$ref` into the `@context`"><div class="ex-tabs">
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex2j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex2y">View as YAML</button></div>
+
+<div class="ex-panel" id="ex2j" role="tabpanel">
+
+<pre><code class="language-json">{
+  &quot;@context&quot;: [
+    &quot;B.schema.json&quot;,
+    &quot;P0.schema.json&quot;,
+    { &quot;p1&quot;: { &quot;@context&quot;: &quot;P1.schema.json&quot; } },
+    { &quot;p2&quot;: { &quot;@context&quot;: [&quot;P2a.schema.json&quot;, &quot;P2b.schema.json&quot;] } },
+    { &quot;p3&quot;: { &quot;@context&quot;: { &quot;keyword_in_P3a&quot;: &quot;ex:Property1&quot;, &quot;keyword_in_P3b&quot;: &quot;ex:Property2&quot; } } }
+  ],
+  &quot;$id&quot;: &quot;A.schema.json&quot;,
+  &quot;allOf&quot;: [ { &quot;$ref&quot;: &quot;B.schema.json&quot; } ],
+  &quot;properties&quot;: {
+    &quot;p0&quot;: { &quot;type&quot;: &quot;string&quot;, &quot;$ref&quot;: &quot;P0.schema.json&quot; },
+    &quot;p1&quot;: { &quot;type&quot;: &quot;object&quot;, &quot;$ref&quot;: &quot;P1.schema.json&quot; },
+    &quot;p2&quot;: { &quot;type&quot;: &quot;object&quot;, &quot;allOf&quot;: [ { &quot;$ref&quot;: &quot;P2a.schema.json&quot; }, { &quot;$ref&quot;: &quot;P2b.schema.json&quot; } ] },
+    &quot;p3&quot;: { &quot;oneOf&quot;: [ { &quot;$ref&quot;: &quot;P3a.schema.json&quot; }, { &quot;$ref&quot;: &quot;P3b.schema.json&quot; } ] }
+  }
+}
+</code></pre>
+</div>
+
+<div class="ex-panel" id="ex2y" role="tabpanel" hidden>
+
+<pre><code class="language-yaml">'@context':
+- B.schema.json
+- P0.schema.json
+- p1:
+    '@context': P1.schema.json
+- p2:
+    '@context':
+    - P2a.schema.json
+    - P2b.schema.json
+- p3:
+    '@context':
       keyword_in_P3a: ex:Property1
       keyword_in_P3b: ex:Property2
 $id: A.schema.json
 allOf:
-  - $ref: B.schema.json
+- $ref: B.schema.json
 properties:
   p0:
     type: string
@@ -334,54 +361,150 @@ properties:
   p2:
     type: object
     allOf:
-      $ref: P2a.schema.json
-      $ref: P2b.schema.json
+    - $ref: P2a.schema.json
+    - $ref: P2b.schema.json
   p3:
     oneOf:
-      $ref: P3a.schema.json
-      $ref: P3b.schema.json
-</code></pre></aside>
+    - $ref: P3a.schema.json
+    - $ref: P3b.schema.json
+</code></pre>
+</div>
+
+</div></aside>
 <aside class="example" title="A nested context and the RDF it produces"><p>A <code>Pet</code> schema:</p>
-<pre><code class="language-yaml">&quot;@context&quot;: 
-  name: ex:petName
+<div class="ex-tabs">
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex3j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex3y">View as YAML</button></div>
+
+<div class="ex-panel" id="ex3j" role="tabpanel">
+
+<pre><code class="language-json">{
+  &quot;$schema&quot;: &quot;https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json&quot;,
+  &quot;$id&quot;: &quot;Pet.schema.json&quot;,
+  &quot;@context&quot;: {
+    &quot;ex&quot;: &quot;https://example.org/&quot;,
+    &quot;name&quot;: &quot;ex:petName&quot;
+  },
+  &quot;title&quot;: &quot;Pet&quot;,
+  &quot;type&quot;: &quot;object&quot;,
+  &quot;properties&quot;: {
+    &quot;name&quot;: { &quot;type&quot;: &quot;string&quot;, &quot;description&quot;: &quot;Name of the pet&quot; }
+  }
+}
+</code></pre>
+</div>
+
+<div class="ex-panel" id="ex3y" role="tabpanel" hidden>
+
+<pre><code class="language-yaml">$schema: https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json
 $id: Pet.schema.json
+'@context':
+  ex: https://example.org/
+  name: ex:petName
+title: Pet
+type: object
 properties:
   name:
     type: string
+    description: Name of the pet
 </code></pre>
-<p>A <code>Person</code> schema that embeds <code>Pet</code> under a property-scoped context:</p>
-<pre><code class="language-yaml">&quot;@context&quot;: 
+</div>
+
+</div>
+
+<p>A <code>PersonWithPet</code> schema that embeds <code>Pet</code> under a property-scoped context:</p>
+<div class="ex-tabs">
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex4j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex4y">View as YAML</button></div>
+
+<div class="ex-panel" id="ex4j" role="tabpanel">
+
+<pre><code class="language-json">{
+  &quot;$schema&quot;: &quot;https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json&quot;,
+  &quot;$id&quot;: &quot;PersonWithPet.schema.json&quot;,
+  &quot;@context&quot;: {
+    &quot;ex&quot;: &quot;https://example.org/&quot;,
+    &quot;schema&quot;: &quot;http://schema.org/&quot;,
+    &quot;name&quot;: &quot;schema:name&quot;,
+    &quot;pets&quot;: { &quot;@id&quot;: &quot;ex:hasPet&quot;, &quot;@container&quot;: &quot;@set&quot;, &quot;@context&quot;: &quot;Pet.schema.json&quot; }
+  },
+  &quot;title&quot;: &quot;Person with pet&quot;,
+  &quot;type&quot;: &quot;object&quot;,
+  &quot;properties&quot;: {
+    &quot;name&quot;: { &quot;type&quot;: &quot;string&quot;, &quot;description&quot;: &quot;Name of the person&quot; },
+    &quot;pets&quot;: {
+      &quot;type&quot;: &quot;array&quot;,
+      &quot;description&quot;: &quot;Pets owned by the person (embedded via a property-scoped context)&quot;,
+      &quot;items&quot;: { &quot;$ref&quot;: &quot;Pet.schema.json&quot; }
+    }
+  }
+}
+</code></pre>
+</div>
+
+<div class="ex-panel" id="ex4y" role="tabpanel" hidden>
+
+<pre><code class="language-yaml">$schema: https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json
+$id: PersonWithPet.schema.json
+'@context':
+  ex: https://example.org/
+  schema: http://schema.org/
   name: schema:name
   pets:
-    &quot;@id&quot;: ex:hasPet
-    &quot;@context&quot;: Pet.schema.json
-$id: Person.schema.json
+    '@id': ex:hasPet
+    '@container': '@set'
+    '@context': Pet.schema.json
+title: Person with pet
+type: object
 properties:
   name:
     type: string
+    description: Name of the person
   pets:
     type: array
-    items: 
+    description: Pets owned by the person (embedded via a property-scoped context)
+    items:
       $ref: Pet.schema.json
 </code></pre>
+</div>
+
+</div>
+
 <p>An instance:</p>
-<pre><code class="language-yaml">&quot;@context&quot;: Person.schema.json
-$schema: Person.schema.json
-name: Max
-pets:
-  - name: Bruno
+<div class="ex-tabs">
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex5j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex5y">View as YAML</button></div>
+
+<div class="ex-panel" id="ex5j" role="tabpanel">
+
+<pre><code class="language-json">{
+  &quot;@context&quot;: &quot;PersonWithPet.schema.json&quot;,
+  &quot;$schema&quot;: &quot;PersonWithPet.schema.json&quot;,
+  &quot;name&quot;: &quot;Max&quot;,
+  &quot;pets&quot;: [ { &quot;name&quot;: &quot;Bruno&quot; } ]
+}
 </code></pre>
-<p>Referencing <code>Person.schema.json</code> as the context is equivalent to inlining the reflected contexts:</p>
-<pre><code class="language-yaml">&quot;@context&quot;: 
-  name: schema:name
-  pets:
-    &quot;@id&quot;: ex:hasPet
-    &quot;@context&quot;:
-      name: ex:petName
-$schema: Person.schema.json
+</div>
+
+<div class="ex-panel" id="ex5y" role="tabpanel" hidden>
+
+<pre><code class="language-yaml">'@context': PersonWithPet.schema.json
+$schema: PersonWithPet.schema.json
 name: Max
 pets:
-  - name: Bruno
+- name: Bruno
+</code></pre>
+</div>
+
+</div>
+
+<p>Referencing <code>PersonWithPet.schema.json</code> as the context is equivalent to inlining the reflected contexts:</p>
+<pre><code class="language-json">{
+  &quot;@context&quot;: {
+    &quot;name&quot;: &quot;schema:name&quot;,
+    &quot;pets&quot;: { &quot;@id&quot;: &quot;ex:hasPet&quot;, &quot;@context&quot;: { &quot;name&quot;: &quot;ex:petName&quot; } }
+  },
+  &quot;$schema&quot;: &quot;PersonWithPet.schema.json&quot;,
+  &quot;name&quot;: &quot;Max&quot;,
+  &quot;pets&quot;: [ { &quot;name&quot;: &quot;Bruno&quot; } ]
+}
 </code></pre>
 <p>which expands (via the reflected contexts) to the RDF:</p>
 <pre><code class="language-ttl">_:b0 &lt;ex:hasPet&gt; _:b1 .
@@ -412,13 +535,14 @@ different parent properties. The mapping is attached to the parent property's te
 <p><strong>Independent references and base URIs.</strong> A JSON Schema <code>$ref</code> and a JSON-LD <code>@context</code> entry are independent references: they <em class="rfc2119">MAY</em> point to the same document (the typical OO-LD case, where one document is both a schema and a context) or to different documents - for example a plain JSON Schema referenced via <code>$ref</code> together with a separate remote <code>@context</code> that supplies the semantics. Relative references resolve against the schema's <code>$id</code> (the JSON Schema base URI) and, on the JSON-LD side, against <code>@base</code> / the retrieval URL; these base URIs <em class="rfc2119">SHOULD</em> be aligned so a relative reference resolves to the same absolute URL under both. <code>$id</code> <em class="rfc2119">MUST NOT</em> contain a non-empty fragment ([[JSONSCHEMA]] §8.2.1).</p></section><section id="merge-and-override-model"><h3>Merge and override model</h3><p>JSON Schema's validation algebra is purely conjunctive: <code>allOf</code> requires an instance to satisfy every subschema, and the specification defines no merge of the subschemas' keyword <em>values</em> ([[JSONSCHEMA]] §10.2.1.1). Several consumers nonetheless require a single <em>[=resolved schema=]</em> view rather than a conjunction: a UI generator needs exactly one <code>title</code> per field, a code generator flattens an inheritance chain into one class, and an OO-LD preprocessor must produce one <code>@context</code>.</p>
 <p>When such a merge is required, OO-LD resolves the <code>allOf</code> chain by applying <strong>JSON Merge Patch ([[RFC7396]]) semantics</strong>: keyed by object member, most-recently-defined (most-derived) wins, and a <code>null</code> value removes a key. For the <code>@context</code> this coincides with JSON-LD's own override rule. For assertion-bearing keywords the resolved view additionally honors <strong>narrow-only</strong> composition: a derived schema <em class="rfc2119">MAY</em> restrict a constraint but <em class="rfc2119">MUST NOT</em> relax it, matching how code generators let a subclass tighten - never loosen - a superclass property's validation.</p>
 <p>This single model governs every place OO-LD collapses composition into a resolved value: single-valued annotations such as <code>title</code> and <code>x-oold-multilang-title</code> resolve most-derived-wins, constraints resolve narrow-only, and additive maps merge by key. A preprocessor applying it produces exactly the view that UI and code generators already compute, so no separate &quot;resolved schema&quot; format is needed.</p></section><section id="closing-composed-objects" class="informative"><h3>Closing composed objects</h3><p>Because <code>allOf</code> composition is conjunctive, <code>additionalProperties: false</code> on one subschema rejects the members that the other composed subschemas contribute, so it cannot close a composed object. To close such an object - rejecting members that no composed subschema declares - use <code>unevaluatedProperties: false</code> ([[JSONSCHEMA]] §11.3), which is evaluated after the <code>allOf</code> branches and therefore accounts for their properties. A schema closed this way should still allow the instance-level <code>$schema</code> and <code>@context</code> members (see <a href="#schema-instances"></a>).</p>
-<aside class="example" title="Closing an inherited object with `unevaluatedProperties`"><pre><code class="language-yaml">$id: Employee.schema.json
-allOf:
-  - $ref: Person.schema.json
-properties:
-  employeeId:
-    type: string
-unevaluatedProperties: false
+<aside class="example" title="Closing an inherited object with `unevaluatedProperties`"><pre><code class="language-json">{
+  &quot;$id&quot;: &quot;Employee.schema.json&quot;,
+  &quot;allOf&quot;: [ { &quot;$ref&quot;: &quot;Person.schema.json&quot; } ],
+  &quot;properties&quot;: {
+    &quot;employeeId&quot;: { &quot;type&quot;: &quot;string&quot; }
+  },
+  &quot;unevaluatedProperties&quot;: false
+}
 </code></pre>
 <p>An instance may carry the <code>Person</code> properties, <code>employeeId</code>, and <code>$schema</code> / <code>@context</code>; any other member is rejected.</p></aside></section></section>
 
@@ -427,8 +551,10 @@ unevaluatedProperties: false
 <li><code>@context</code> - the schema URL, loaded as a JSON-LD remote context. This is what makes the instance a JSON-LD document.</li>
 <li><code>$schema</code> - the schema URL, identifying the schema the instance is intended to validate against.</li>
 </ul>
-<aside class="example" title="An instance referencing its schema"><pre><code class="language-yaml">&quot;@context&quot;: https://example.org/my-package/1.0.0/Person.schema.json
-$schema: https://example.org/my-package/1.0.0/Person.schema.json
+<aside class="example" title="An instance referencing its schema"><pre><code class="language-json">{
+  &quot;@context&quot;: &quot;https://example.org/my-package/1.0.0/Person.schema.json&quot;,
+  &quot;$schema&quot;: &quot;https://example.org/my-package/1.0.0/Person.schema.json&quot;
+}
 </code></pre></aside>
 <p>Instances <em class="rfc2119">SHOULD</em> use a versioned schema URL so that it is unambiguous which schema version they conform to.</p><section id="referencing-schema"><h3>Referencing the schema with <code>$schema</code></h3><p>In standard JSON Schema, <code>$schema</code> identifies the dialect (meta-schema), not the schema an instance validates against ([[JSONSCHEMA]] §8.1.1); JSON Schema does not define an in-band way for an instance to point at its own schema. OO-LD therefore uses <code>$schema</code> on instances as a convention: standard JSON Schema validators treat it as ordinary data, while editors (VS Code, JetBrains, JSON Schema Store) and CI checks (e.g. <a href="https://github.com/thiagowfx/check-json-schema-meta">check-json-schema-meta</a>) honor it. Where the instance is served over HTTP, the standards-conformant alternative is the <code>describedby</code> link relation ([[JSONSCHEMA]] §9.5.1.1), optionally with the <code>profile</code> media-type parameter ([[RFC6906]]):</p>
 <aside class="example" title="Linking an instance to its schema over HTTP"><pre><code class="language-http">Link: &lt;https://example.org/my-package/1.0.0/Person.schema.json&gt;; rel=&quot;describedby&quot;
@@ -484,15 +610,14 @@ $schema: https://example.org/my-package/1.0.0/Person.schema.json
 <li>a <strong>reference</strong> - an object carrying an <code>@id</code> (or its <code>id</code> alias), e.g. <code>{ &quot;id&quot;: &quot;https://example.org/PlaceA&quot; }</code>, denoting an independent entity by IRI;</li>
 <li>an <strong>embedded object</strong> - a nested object with its own properties and no independent identity, e.g. <code>{ &quot;type&quot;: &quot;PostalAddress&quot;, &quot;streetAddress&quot;: &quot;...&quot; }</code>, which becomes a blank node.</li>
 </ul>
-<aside class="example" title="One `address` property, three value forms"><pre><code class="language-json">{
-  &quot;address&quot;: &quot;Mainstreet 1, 10115 Example City&quot;
-}
-{
-  &quot;address&quot;: { &quot;id&quot;: &quot;https://example.org/address/A1&quot; }
-}
-{
-  &quot;address&quot;: { &quot;type&quot;: &quot;PostalAddress&quot;, &quot;streetAddress&quot;: &quot;Mainstreet 1&quot;, &quot;postalCode&quot;: &quot;10115&quot; }
-}
+<aside class="example" title="One `address` property, three value forms"><p>Literal:</p>
+<pre><code class="language-json">{ &quot;address&quot;: &quot;Mainstreet 1, 10115 Example City&quot; }
+</code></pre>
+<p>Reference (by <code>id</code>/<code>@id</code>):</p>
+<pre><code class="language-json">{ &quot;address&quot;: { &quot;id&quot;: &quot;https://example.org/address/A1&quot; } }
+</code></pre>
+<p>Embedded object:</p>
+<pre><code class="language-json">{ &quot;address&quot;: { &quot;type&quot;: &quot;PostalAddress&quot;, &quot;streetAddress&quot;: &quot;Mainstreet 1&quot;, &quot;postalCode&quot;: &quot;10115&quot; } }
 </code></pre></aside>
 <p>A single <code>@context</code> term cannot interpret a bare string as <strong>both</strong> a literal and an IRI: <code>@type: &quot;@id&quot;</code> coerces every string value to an IRI (so free text becomes an - often invalid, then dropped - IRI), while a plain term keeps every string a literal. A property whose range is references only therefore uses <code>@type: &quot;@id&quot;</code> and <em class="rfc2119">MAY</em> be written as a bare IRI string; a property whose range includes free text <em class="rfc2119">MUST NOT</em> use <code>@type: &quot;@id&quot;</code>.</p>
 <p>For a property whose range mixes free text with references and/or embedded objects (for example <code>Text | PostalAddress | Place</code>), two patterns keep the instance round-trippable (see <a href="#round-trip"></a>); a model ecosystem <em class="rfc2119">SHOULD</em> adopt one of them consistently:</p>
@@ -530,31 +655,39 @@ $schema: https://example.org/my-package/1.0.0/Person.schema.json
 <div class="note" title="Typed literals canonicalize"><p>A datatype-coerced value round-trips by RDF value, not byte-for-byte: e.g. the JSON number <code>40.75</code> under <code>@type: &quot;xsd:float&quot;</code> becomes the canonical lexical form <code>&quot;4.075E1&quot;</code> and returns as that string. Round-trip equality for typed literals is value equality after datatype canonicalization.</p></div></section></section>
 
 <section id="identification-versioning"><h2>Identification and Versioning</h2><section id="identification"><h3>Identification</h3><p>OO-LD schemas <em class="rfc2119">MUST</em> have a <code>$id</code> ([[JSONSCHEMA]] §8.2.1) which works as a global and unique identifier of the schema. The value of <code>$id</code> <em class="rfc2119">MAY</em> be an absolute URI (details below). The schema <em class="rfc2119">SHOULD</em> be resolvable via this URI. The schema <em class="rfc2119">SHOULD</em> have an annotation <code>x-oold-uuid</code> with a UUID value.</p>
-<aside class="example" title="A schema `$id` and its `x-oold-uuid`"><pre><code class="language-yaml">$id: https://example.org/Foo.schema.json
-x-oold-uuid: b5203131-7321-46bb-8a11-acb3d1015840
-title: Foo
+<aside class="example" title="A schema `$id` and its `x-oold-uuid`"><pre><code class="language-json">{
+  &quot;$id&quot;: &quot;https://example.org/Foo.schema.json&quot;,
+  &quot;x-oold-uuid&quot;: &quot;b5203131-7321-46bb-8a11-acb3d1015840&quot;,
+  &quot;title&quot;: &quot;Foo&quot;
+}
 </code></pre>
 <p>It is recommended to use the UUID also in the <code>$id</code>:</p>
-<pre><code class="language-yaml">$id: https://example.org/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
-x-oold-uuid: b5203131-7321-46bb-8a11-acb3d1015840
-title: Foo
+<pre><code class="language-json">{
+  &quot;$id&quot;: &quot;https://example.org/b5203131-7321-46bb-8a11-acb3d1015840.schema.json&quot;,
+  &quot;x-oold-uuid&quot;: &quot;b5203131-7321-46bb-8a11-acb3d1015840&quot;,
+  &quot;title&quot;: &quot;Foo&quot;
+}
 </code></pre></aside></section><section id="ontology-class-iri"><h3>Ontology class IRI (<code>x-oold-iri</code>)</h3><p><code>x-oold-iri</code> declares the IRI of the ontology class that this schema realizes - the RDF/OWL class from an external vocabulary that gives the schema its semantic grounding. It is distinct from two related IRIs:</p>
 <ul>
 <li><code>$id</code> - the URL of the schema document (where to fetch it). A schema document is a retrievable artifact, not an OWL class.</li>
 <li><code>x-oold-instance-rdf-type</code> - the <code>rdf:type</code>s that instances carry on export (see <a href="#semantic-type"></a>). These are stamped onto instance data; <code>x-oold-iri</code> describes the schema itself.</li>
 </ul>
-<aside class="example" title="Distinguishing document URL, ontology class, and instance type"><pre><code class="language-yaml">$id: https://example.org/my-package/1.0.0/Person.schema.json
-x-oold-iri: https://schema.org/Person
-x-oold-instance-rdf-type: [&quot;schema:Person&quot;]
-title: Person
+<aside class="example" title="Distinguishing document URL, ontology class, and instance type"><pre><code class="language-json">{
+  &quot;$id&quot;: &quot;https://example.org/my-package/1.0.0/Person.schema.json&quot;,
+  &quot;x-oold-iri&quot;: &quot;https://schema.org/Person&quot;,
+  &quot;x-oold-instance-rdf-type&quot;: [&quot;schema:Person&quot;],
+  &quot;title&quot;: &quot;Person&quot;
+}
 </code></pre></aside>
 <p>In this example, the schema document is fetched from the <code>$id</code> URL, it realizes the ontology class <code>schema:Person</code>, and instances exported to RDF carry <code>@type: schema:Person</code>. The most common case is that <code>x-oold-iri</code> and the entries in <code>x-oold-instance-rdf-type</code> resolve to the same IRI, but they may differ - for example when a schema models a more specific subclass inline while still emitting a broader <code>rdf:type</code> on instances.</p>
 <p>OO-LD-aware tooling uses <code>x-oold-iri</code> to anchor the schema in an ontology graph, independently of where the schema document is hosted - for example to resolve super-classes, look up ontology annotations, or generate SHACL shapes.</p></section><section id="versioning"><h3>Versioning</h3><p>The schema version <em class="rfc2119">SHOULD</em> be indicated by <code>x-oold-version</code>; a prior version <em class="rfc2119">MAY</em> be indicated with <code>x-oold-prior-version</code>:</p>
-<aside class="example" title="Version annotations"><pre><code class="language-yaml">$id: https://example.org/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
-x-oold-uuid: b5203131-7321-46bb-8a11-acb3d1015840
-title: Foo
-x-oold-version: 1.1.0
-x-oold-prior-version: 1.0.0
+<aside class="example" title="Version annotations"><pre><code class="language-json">{
+  &quot;$id&quot;: &quot;https://example.org/b5203131-7321-46bb-8a11-acb3d1015840.schema.json&quot;,
+  &quot;x-oold-uuid&quot;: &quot;b5203131-7321-46bb-8a11-acb3d1015840&quot;,
+  &quot;title&quot;: &quot;Foo&quot;,
+  &quot;x-oold-version&quot;: &quot;1.1.0&quot;,
+  &quot;x-oold-prior-version&quot;: &quot;1.0.0&quot;
+}
 </code></pre></aside>
 <p>The version <em class="rfc2119">SHOULD</em> be part of the schema's location:</p>
 <ul>
@@ -564,29 +697,35 @@ x-oold-prior-version: 1.0.0
 </ul>
 <p>Since a package combines multiple schemas, the package version does in general not match the individual schema version.</p>
 <p>Schemas <em class="rfc2119">MAY</em> indicate explicit backward-compatibility with <code>x-oold-backward-compatible-with</code> and <code>x-oold-incompatible-with</code>:</p>
-<aside class="example" title="Declaring backward-compatibility"><pre><code class="language-yaml">$id: https://example.org/my-package/2.1.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
-x-oold-uuid: b5203131-7321-46bb-8a11-acb3d1015840
-title: Foo
-x-oold-version: 1.1.0
-x-oold-prior-version: 1.0.0
-x-oold-backward-compatible-with: https://example.org/my-package/2.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
-x-oold-incompatible-with: https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
+<aside class="example" title="Declaring backward-compatibility"><pre><code class="language-json">{
+  &quot;$id&quot;: &quot;https://example.org/my-package/2.1.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json&quot;,
+  &quot;x-oold-uuid&quot;: &quot;b5203131-7321-46bb-8a11-acb3d1015840&quot;,
+  &quot;title&quot;: &quot;Foo&quot;,
+  &quot;x-oold-version&quot;: &quot;1.1.0&quot;,
+  &quot;x-oold-prior-version&quot;: &quot;1.0.0&quot;,
+  &quot;x-oold-backward-compatible-with&quot;: &quot;https://example.org/my-package/2.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json&quot;,
+  &quot;x-oold-incompatible-with&quot;: &quot;https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json&quot;
+}
 </code></pre></aside>
 <p>Schemas within a package or package repository <em class="rfc2119">MAY</em> use relative URIs ([[RFC3986]] §5.1). For example, <code>A.schema.json</code> referenced from <code>https://raw.githubusercontent.com/MyOrg/my-package/refs/heads/2.0.0/</code>:</p>
-<aside class="example" title="Relative `$ref` inside a package"><pre><code class="language-yaml">$id: B.schema.json
-title: Foo
-allOf:
-  - $ref: A.schema.json
+<aside class="example" title="Relative `$ref` inside a package"><pre><code class="language-json">{
+  &quot;$id&quot;: &quot;B.schema.json&quot;,
+  &quot;title&quot;: &quot;Foo&quot;,
+  &quot;allOf&quot;: [ { &quot;$ref&quot;: &quot;A.schema.json&quot; } ]
+}
 </code></pre>
 <p>expands to:</p>
-<pre><code class="language-yaml">$id: https://raw.githubusercontent.com/MyOrg/my-package/refs/heads/2.0.0/B.schema.json
-title: Foo
-allOf:
-  - $ref: https://raw.githubusercontent.com/MyOrg/my-package/refs/heads/2.0.0/A.schema.json
+<pre><code class="language-json">{
+  &quot;$id&quot;: &quot;https://raw.githubusercontent.com/MyOrg/my-package/refs/heads/2.0.0/B.schema.json&quot;,
+  &quot;title&quot;: &quot;Foo&quot;,
+  &quot;allOf&quot;: [ { &quot;$ref&quot;: &quot;https://raw.githubusercontent.com/MyOrg/my-package/refs/heads/2.0.0/A.schema.json&quot; } ]
+}
 </code></pre></aside>
 <p>Instance documents <em class="rfc2119">SHOULD</em> always use a versioned schema URL to make clear which schema version they comply with:</p>
-<aside class="example" title="An instance pinned to a schema version"><pre><code class="language-yaml">&quot;@context&quot;: https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
-$schema: https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
+<aside class="example" title="An instance pinned to a schema version"><pre><code class="language-json">{
+  &quot;@context&quot;: &quot;https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json&quot;,
+  &quot;$schema&quot;: &quot;https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json&quot;
+}
 </code></pre></aside>
 <p>Upgrade APIs <em class="rfc2119">MAY</em> provide automated data migration between schema (package) versions, e.g. <code>https://example.org/upgrade/my-package/1.0.0...2.0.0</code>.</p></section></section>
 
@@ -614,42 +753,100 @@ $schema: https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d10158
 _:b0 &lt;schema:name&gt; &quot;test&quot; .
 </code></pre></aside>
 <p>The notation can also drive data transformation and normalization. For example, a dataset in which persons and organizations report their relations in a syntactically non-interoperable way can be normalized into a consistent unified dataset (see <a href="https://github.com/OO-LD/oold-schema/issues/11">OO-LD/oold-schema#11</a>).</p>
-<aside class="example" title="Normalizing a syntactically non-interoperable dataset"><p>Input - the same relation is reported in three different ways (<code>works_for</code>, a distinct <code>works_for*</code>, and a backward <code>employees</code>):</p>
-<pre><code class="language-yaml">&quot;@graph&quot;:
+<aside class="example" title="Normalizing a syntactically non-interoperable dataset"><p>Input - the same relation is reported in three different ways: a forward <code>works_for</code>, a distinct forward <code>works_for*</code>, and a backward <code>employees</code>:</p>
+<div class="ex-tabs">
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex6j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex6y">View as YAML</button></div>
+
+<div class="ex-panel" id="ex6j" role="tabpanel">
+
+<pre><code class="language-json">{
+  &quot;@graph&quot;: [
+    {
+      &quot;id&quot;: &quot;demo:person1&quot;,
+      &quot;type&quot;: &quot;schema:Person&quot;,
+      &quot;name&quot;: &quot;Person1&quot;,
+      &quot;works_for&quot;: &quot;demo:organizationA&quot;,
+      &quot;works_for*&quot;: &quot;demo:organizationB&quot;
+    },
+    { &quot;id&quot;: &quot;demo:organizationA&quot;, &quot;type&quot;: &quot;schema:Organization&quot; },
+    { &quot;id&quot;: &quot;demo:organizationB&quot;, &quot;type&quot;: &quot;schema:Organization&quot; },
+    {
+      &quot;id&quot;: &quot;demo:organizationC&quot;,
+      &quot;type&quot;: &quot;schema:Organization&quot;,
+      &quot;employees&quot;: &quot;demo:person1&quot;
+    }
+  ]
+}
+</code></pre>
+</div>
+
+<div class="ex-panel" id="ex6y" role="tabpanel" hidden>
+
+<pre><code class="language-yaml">'@graph':
 - id: demo:person1
   type: schema:Person
   name: Person1
-  works_for: demo:organizationA # forward relation
-  works_for*: demo:organizationB # forward relation but different property
+  works_for: demo:organizationA
+  works_for*: demo:organizationB
 - id: demo:organizationA
   type: schema:Organization
 - id: demo:organizationB
   type: schema:Organization
 - id: demo:organizationC
   type: schema:Organization
-  employees: demo:person1 # backwards relation
+  employees: demo:person1
 </code></pre>
+</div>
+
+</div>
+
 <p>Normalized - a single, consistent representation:</p>
-<pre><code class="language-yaml">&quot;@graph&quot;:
-- employees:
+<div class="ex-tabs">
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex7j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex7y">View as YAML</button></div>
+
+<div class="ex-panel" id="ex7j" role="tabpanel">
+
+<pre><code class="language-json">{
+  &quot;@graph&quot;: [
+    {
+      &quot;id&quot;: &quot;demo:organizationA&quot;,
+      &quot;type&quot;: &quot;schema:Organization&quot;,
+      &quot;employees&quot;: [&quot;demo:person1&quot;, &quot;demo:person2&quot;, &quot;demo:person3&quot;],
+      &quot;label&quot;: [ { &quot;lang&quot;: &quot;en&quot;, &quot;text&quot;: &quot;organizationA&quot; } ]
+    },
+    { &quot;id&quot;: &quot;demo:person1&quot;, &quot;type&quot;: &quot;schema:Person&quot;, &quot;name&quot;: &quot;Person1&quot; },
+    { &quot;id&quot;: &quot;demo:person2&quot;, &quot;type&quot;: &quot;schema:Person&quot;, &quot;name&quot;: &quot;Person2&quot; },
+    { &quot;id&quot;: &quot;demo:person3&quot;, &quot;type&quot;: &quot;schema:Person&quot;, &quot;name&quot;: &quot;Person3&quot; }
+  ]
+}
+</code></pre>
+</div>
+
+<div class="ex-panel" id="ex7y" role="tabpanel" hidden>
+
+<pre><code class="language-yaml">'@graph':
+- id: demo:organizationA
+  type: schema:Organization
+  employees:
   - demo:person1
   - demo:person2
   - demo:person3
-  id: demo:organizationA
   label:
   - lang: en
     text: organizationA
-  type: schema:Organization
 - id: demo:person1
+  type: schema:Person
   name: Person1
-  type: schema:Person
 - id: demo:person2
+  type: schema:Person
   name: Person2
-  type: schema:Person
 - id: demo:person3
-  name: Person3
   type: schema:Person
-</code></pre></aside></section><section id="synonyms"><h4>Term mappings and synonyms (<code>x-oold-context</code>)</h4><p>The <code>*</code> notation above documents at most a small, fixed set of alternative <code>@id</code>s inline and carries no metadata about each mapping. For the general case OO-LD adds the schema-level keyword <code>x-oold-context</code>: an object keyed by term, where each term holds a dict keyed by the <strong>synonym IRI</strong>.</p>
+  name: Person3
+</code></pre>
+</div>
+
+</div></aside></section><section id="synonyms"><h4>Term mappings and synonyms (<code>x-oold-context</code>)</h4><p>The <code>*</code> notation above documents at most a small, fixed set of alternative <code>@id</code>s inline and carries no metadata about each mapping. For the general case OO-LD adds the schema-level keyword <code>x-oold-context</code>: an object keyed by term, where each term holds a dict keyed by the <strong>synonym IRI</strong>.</p>
 <p>In the minimal case a term simply lists alternative IRIs, each with an empty value (<code>{}</code>):</p>
 <aside class="example" title="Minimal case - a term with alias IRIs"><pre><code class="language-json">{
   &quot;@context&quot;: { &quot;description&quot;: &quot;schema:description&quot; },
@@ -843,11 +1040,16 @@ ex:p2    a schema:Person ; schema:worksFor ex:org1 .
 intersections (<code>allOf</code>) and inline constraints can be combined to describe an anonymous subclass. References to other schemas inside <code>x-oold-range</code> <em class="rfc2119">MUST</em> use <code>x-oold-ref</code>, never <code>$ref</code> (see below). The single-IRI form (1) is a shorthand for <code>{ &quot;allOf&quot;: [ { &quot;x-oold-ref&quot;: &quot;Organization.schema.json&quot; } ] }</code>:</p>
 </li>
 </ol>
-<aside class="example" title="Range as a subschema (Organization located in Germany)"><pre><code class="language-json">&quot;x-oold-range&quot;: {
-  &quot;allOf&quot;: [
-    { &quot;x-oold-ref&quot;: &quot;Organization.schema.json&quot; },
-    { &quot;properties&quot;: { &quot;address&quot;: { &quot;properties&quot;: { &quot;country&quot;: { &quot;const&quot;: &quot;DE&quot; } } } } }
-  ]
+<aside class="example" title="Range as a subschema (Organization located in Germany)"><pre><code class="language-json">{
+  &quot;works_for&quot;: {
+    &quot;type&quot;: &quot;string&quot;,
+    &quot;x-oold-range&quot;: {
+      &quot;allOf&quot;: [
+        { &quot;x-oold-ref&quot;: &quot;Organization.schema.json&quot; },
+        { &quot;properties&quot;: { &quot;address&quot;: { &quot;properties&quot;: { &quot;country&quot;: { &quot;const&quot;: &quot;DE&quot; } } } } }
+      ]
+    }
+  }
 }
 </code></pre></aside>
 <p>A range subschema <em class="rfc2119">MAY</em> also carry additional annotations (e.g. <code>title</code>, <code>description</code> or further <code>x-oold-*</code> keywords) to support tooling - for example a human-readable label for an autocomplete dropdown, or hints used when generating a SHACL shape.</p><section id="range-reference-form"><h5>Lexical form of the reference</h5><p>The value of an IRI-valued property is a JSON string. Its role as a reference comes from the <code>@context</code> (<code>&quot;@type&quot;: &quot;@id&quot;</code>) and its class from <code>x-oold-range</code>. Its <em>lexical</em> form <em class="rfc2119">SHOULD</em> be constrained with an IRI/URI-family <code>format</code> so that malformed values are rejected; the choices, from most to least permissive:</p>
@@ -857,59 +1059,171 @@ intersections (<code>allOf</code>) and inline constraints can be combined to des
 <li><strong>Stricter, ASCII only</strong> - <code>&quot;format&quot;: &quot;uri&quot;</code> or <code>&quot;uri-reference&quot;</code>, where values are known not to use internationalized (non-ASCII) IRIs.</li>
 <li><strong>Compact form specifically</strong> - a <code>&quot;pattern&quot;</code> such as <code>&quot;^[A-Za-z_][\\w.-]*:(?!//)\\S*$&quot;</code>, which accepts <code>ex:alice</code> and <code>schema:Person</code> while rejecting <code>http://…</code>; the prefix <em class="rfc2119">MUST</em> be defined in the <code>@context</code>.</li>
 </ul></section><section id="why-x-oold-ref"><h5>Why <code>x-oold-ref</code> and not <code>$ref</code></h5><p><code>x-oold-range</code> is a custom keyword, so a <code>$ref</code> placed inside it is undefined behavior for generic JSON Schema tooling ([[JSONSCHEMA]] §9.4.2). In practice the behavior is not merely undefined but inconsistent: generic reference resolvers eagerly inline such a <code>$ref</code>, and because <code>x-oold-range</code> targets can form a cyclic graph of schemas this can pull in an unbounded graph, while schema-aware bundlers instead drop it.</p>
-<p><code>x-oold-ref</code> avoids this. Generic tools only follow the standard <code>$ref</code> keyword, so they leave <code>x-oold-ref</code> untouched; OO-LD-aware tools resolve it deliberately and lazily, with cycle detection. The standard <code>$ref</code> continues to be used for ordinary schema composition (<code>allOf</code>, <code>properties</code>, <code>$defs</code>), which bundlers are expected to resolve. Because the only difference is the keyword name, the mapping is reversible: an OO-LD-aware tool can mechanically replace <code>x-oold-ref</code> with <code>$ref</code> to obtain a plain, fully-resolvable JSON Schema - the explicit opt-in to resolving the (possibly cyclic) graph.</p></section><section id="range-generation-targets" class="informative"><h5>Generation targets</h5><p><code>x-oold-range</code> (and the reverse properties below) exist so that the logical and conceptual modelling layers can be generated from the same OO-LD source instead of being maintained separately: a range constrains the type of a referenced object, which an OO-LD-aware tool emits as a <a href="https://www.w3.org/TR/shacl/">SHACL</a> property shape (<code>sh:class</code> / <code>sh:node</code>) and as an OWL property restriction. <a href="https://www.w3.org/TR/shacl12-core/">SHACL 1.2</a> (in progress, including Node Expressions for derived values) and OWL are the intended targets. These are generation targets, not additional validation performed by generic JSON Schema tools.</p></section></section><section id="reverse-properties"><h4>Reverse properties</h4><p>Many relations are symmetric (e.g. Organization employs Person ⇔ Person works for Organization) and users want to edit them from both sides, without storing the information twice. The keywords <code>x-oold-reverse-properties</code> and <code>x-oold-reverse-required</code> declare such a [=reverse property=], mapped with JSON-LD <code>@reverse</code> in the <code>@context</code>. (The earlier <code>x-oold-reverse-default-properties</code> array is deprecated: mark a reverse property shown by default with <code>x-oold-ui-default-property</code> on the property itself - see <a href="#ui-generation"></a> - which, unlike the merged array, is overridable under composition.) To make <code>employees</code> the reverse of <code>organization</code>:</p>
+<p><code>x-oold-ref</code> avoids this. Generic tools only follow the standard <code>$ref</code> keyword, so they leave <code>x-oold-ref</code> untouched; OO-LD-aware tools resolve it deliberately and lazily, with cycle detection. The standard <code>$ref</code> continues to be used for ordinary schema composition (<code>allOf</code>, <code>properties</code>, <code>$defs</code>), which bundlers are expected to resolve. Because the only difference is the keyword name, the mapping is reversible: an OO-LD-aware tool can mechanically replace <code>x-oold-ref</code> with <code>$ref</code> to obtain a plain, fully-resolvable JSON Schema - the explicit opt-in to resolving the (possibly cyclic) graph.</p></section><section id="range-generation-targets" class="informative"><h5>Generation targets</h5><p><code>x-oold-range</code> (and the reverse properties below) exist so that the logical and conceptual modelling layers can be generated from the same OO-LD source instead of being maintained separately: a range constrains the type of a referenced object, which an OO-LD-aware tool emits as a <a href="https://www.w3.org/TR/shacl/">SHACL</a> property shape (<code>sh:class</code> / <code>sh:node</code>) and as an OWL property restriction. <a href="https://www.w3.org/TR/shacl12-core/">SHACL 1.2</a> (in progress, including Node Expressions for derived values) and OWL are the intended targets. These are generation targets, not additional validation performed by generic JSON Schema tools.</p></section></section><section id="reverse-properties"><h4>Reverse properties</h4><p>Many relations are symmetric (e.g. Organization employs Person ⇔ Person works for Organization) and users want to edit them from both sides, without storing the information twice. The keywords <code>x-oold-reverse-properties</code> and <code>x-oold-reverse-required</code> declare such a [=reverse property=], mapped with JSON-LD <code>@reverse</code> in the <code>@context</code>. (The earlier <code>x-oold-reverse-default-properties</code> array is deprecated: mark a reverse property shown by default with <code>x-oold-ui-default-property</code> on the property itself - see <a href="#ui-generation"></a> - which, unlike the merged array, is overridable under composition.) To make <code>employees</code> the reverse of <code>works_for</code>:</p>
 <ul>
-<li>define <code>employees</code> in <code>x-oold-reverse-properties</code> of <code>Organization</code>;</li>
-<li>define <code>organization</code> in the <code>properties</code> of <code>Person</code>;</li>
-<li>map <code>organization</code> to a semantic property, e.g. <code>schema:worksFor</code>, in the <code>@context</code> of <code>Person</code>;</li>
-<li>map <code>employees</code> with <code>@reverse</code> to the same property in the <code>@context</code> of <code>Organization</code> ([[JSON-LD11]] reverse properties).</li>
+<li>define <code>works_for</code> in the <code>properties</code> of <code>Person</code>, mapped to a semantic property (<code>schema:worksFor</code>) in the <code>@context</code> of <code>Person</code>;</li>
+<li>define <code>employees</code> in <code>x-oold-reverse-properties</code> of <code>Organization</code>, mapped with <code>@reverse</code> to the same property in the <code>@context</code> of <code>Organization</code> ([[JSON-LD11]] reverse properties).</li>
 </ul>
-<aside class="example" title="Reverse property across two schemas"><p><code>Organization.schema.json</code>:</p>
+<aside class="example" title="Reverse property across two schemas"><p><code>Organization.schema.json</code> declares <code>employees</code> as the reverse property (the <code>address</code> composition and <code>Thing</code> inheritance are unrelated to this demonstration):</p>
+<div class="ex-tabs">
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex8j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex8y">View as YAML</button></div>
+
+<div class="ex-panel" id="ex8j" role="tabpanel">
+
 <pre><code class="language-json">{
+  &quot;$schema&quot;: &quot;https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json&quot;,
+  &quot;$id&quot;: &quot;Organization.schema.json&quot;,
+  &quot;x-oold-uuid&quot;: &quot;c6314242-8432-57cc-9b22-bd4e2026951f&quot;,
+  &quot;x-oold-version&quot;: &quot;1.0.0&quot;,
+  &quot;x-oold-instance-rdf-type&quot;: [&quot;schema:Organization&quot;],
   &quot;@context&quot;: [
-    { &quot;employees&quot;: { &quot;@reverse&quot;: &quot;schema:worksFor&quot;, &quot;@type&quot;: &quot;@id&quot; } }
+    &quot;Thing.schema.json&quot;,
+    {
+      &quot;schema&quot;: &quot;http://schema.org/&quot;,
+      &quot;address&quot;: { &quot;@id&quot;: &quot;schema:address&quot;, &quot;@context&quot;: &quot;Address.schema.json&quot; },
+      &quot;employees&quot;: { &quot;@reverse&quot;: &quot;schema:worksFor&quot;, &quot;@type&quot;: &quot;@id&quot; }
+    }
   ],
   &quot;title&quot;: &quot;Organization&quot;,
+  &quot;x-oold-multilang-title&quot;: { &quot;en&quot;: &quot;Organization&quot;, &quot;de&quot;: &quot;Organisation&quot; },
+  &quot;allOf&quot;: [ { &quot;$ref&quot;: &quot;Thing.schema.json&quot; } ],
   &quot;type&quot;: &quot;object&quot;,
-  &quot;required&quot;: [&quot;type&quot;],
-  &quot;x-oold-reverse-required&quot;: [],
+  &quot;properties&quot;: {
+    &quot;address&quot;: {
+      &quot;type&quot;: &quot;object&quot;,
+      &quot;$ref&quot;: &quot;Address.schema.json&quot;,
+      &quot;description&quot;: &quot;Postal address of the organization&quot;
+    }
+  },
   &quot;x-oold-reverse-properties&quot;: {
     &quot;employees&quot;: {
       &quot;type&quot;: &quot;array&quot;,
       &quot;title&quot;: &quot;Employees&quot;,
+      &quot;description&quot;: &quot;Persons who work for this organization; stored on each Person as works_for, editable here via JSON-LD @reverse.&quot;,
       &quot;x-oold-ui-default-property&quot;: true,
       &quot;items&quot;: {
         &quot;type&quot;: &quot;string&quot;,
-        &quot;format&quot;: &quot;autocomplete&quot;,
-        &quot;title&quot;: &quot;Person&quot;,
+        &quot;format&quot;: &quot;iri-reference&quot;,
         &quot;x-oold-range&quot;: &quot;Person.schema.json&quot;
       }
     }
   }
 }
 </code></pre>
-<p><code>Person.schema.json</code>:</p>
+</div>
+
+<div class="ex-panel" id="ex8y" role="tabpanel" hidden>
+
+<pre><code class="language-yaml">$schema: https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json
+$id: Organization.schema.json
+x-oold-uuid: c6314242-8432-57cc-9b22-bd4e2026951f
+x-oold-version: 1.0.0
+x-oold-instance-rdf-type:
+- schema:Organization
+'@context':
+- Thing.schema.json
+- schema: http://schema.org/
+  address:
+    '@id': schema:address
+    '@context': Address.schema.json
+  employees:
+    '@reverse': schema:worksFor
+    '@type': '@id'
+title: Organization
+x-oold-multilang-title:
+  en: Organization
+  de: Organisation
+allOf:
+- $ref: Thing.schema.json
+type: object
+properties:
+  address:
+    type: object
+    $ref: Address.schema.json
+    description: Postal address of the organization
+x-oold-reverse-properties:
+  employees:
+    type: array
+    title: Employees
+    description: Persons who work for this organization; stored on each Person as works_for, editable
+      here via JSON-LD @reverse.
+    x-oold-ui-default-property: true
+    items:
+      type: string
+      format: iri-reference
+      x-oold-range: Person.schema.json
+</code></pre>
+</div>
+
+</div>
+
+<p><code>Person.schema.json</code> carries the forward <code>works_for</code> property:</p>
+<div class="ex-tabs">
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex9j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex9y">View as YAML</button></div>
+
+<div class="ex-panel" id="ex9j" role="tabpanel">
+
 <pre><code class="language-json">{
+  &quot;$schema&quot;: &quot;https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json&quot;,
+  &quot;$id&quot;: &quot;Person.schema.json&quot;,
+  &quot;x-oold-uuid&quot;: &quot;b5203131-7321-46bb-8a11-acb3d1015840&quot;,
+  &quot;x-oold-version&quot;: &quot;1.0.0&quot;,
+  &quot;x-oold-instance-rdf-type&quot;: [&quot;schema:Person&quot;],
   &quot;@context&quot;: [
-    { &quot;organization&quot;: { &quot;@id&quot;: &quot;schema:worksFor&quot;, &quot;@type&quot;: &quot;@id&quot; } }
+    &quot;Thing.schema.json&quot;,
+    {
+      &quot;schema&quot;: &quot;http://schema.org/&quot;,
+      &quot;works_for&quot;: { &quot;@id&quot;: &quot;schema:worksFor&quot;, &quot;@type&quot;: &quot;@id&quot; }
+    }
   ],
   &quot;title&quot;: &quot;Person&quot;,
-  &quot;defaultProperties&quot;: [&quot;organization&quot;],
+  &quot;x-oold-multilang-title&quot;: { &quot;en&quot;: &quot;Person&quot;, &quot;de&quot;: &quot;Person&quot; },
+  &quot;allOf&quot;: [ { &quot;$ref&quot;: &quot;Thing.schema.json&quot; } ],
+  &quot;type&quot;: &quot;object&quot;,
   &quot;properties&quot;: {
-    &quot;organization&quot;: {
-      &quot;title&quot;: &quot;Organization&quot;,
-      &quot;description&quot;: &quot;Organization(s) the person is affiliated with. E.g., university, research institute, company, etc.&quot;,
-      &quot;type&quot;: &quot;array&quot;,
-      &quot;items&quot;: {
-        &quot;type&quot;: &quot;string&quot;,
-        &quot;format&quot;: &quot;autocomplete&quot;,
-        &quot;x-oold-range&quot;: &quot;Organization.schema.json&quot;
-      }
+    &quot;works_for&quot;: {
+      &quot;type&quot;: &quot;string&quot;,
+      &quot;format&quot;: &quot;iri-reference&quot;,
+      &quot;description&quot;: &quot;Organization the person works for (IRI reference)&quot;,
+      &quot;x-oold-range&quot;: &quot;Organization.schema.json&quot;
     }
   }
 }
-</code></pre></aside>
-<p>An OO-LD-aware implementation uses this to read and modify properties that are actually stored in another object: loading an <code>Organization</code> editor prepopulates <code>employees</code> by querying which persons work for it; storing the <code>Organization</code> writes it into each referenced person's <code>organization</code> field; and removing a person from <code>employees</code> removes the organization from theirs.</p></section><section id="ui-generation" class="informative"><h4>UI Generation</h4><p>OO-LD schemas double as the source for auto-generated forms and views. UI intent is carried in two layers:</p>
+</code></pre>
+</div>
+
+<div class="ex-panel" id="ex9y" role="tabpanel" hidden>
+
+<pre><code class="language-yaml">$schema: https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json
+$id: Person.schema.json
+x-oold-uuid: b5203131-7321-46bb-8a11-acb3d1015840
+x-oold-version: 1.0.0
+x-oold-instance-rdf-type:
+- schema:Person
+'@context':
+- Thing.schema.json
+- schema: http://schema.org/
+  works_for:
+    '@id': schema:worksFor
+    '@type': '@id'
+title: Person
+x-oold-multilang-title:
+  en: Person
+  de: Person
+allOf:
+- $ref: Thing.schema.json
+type: object
+properties:
+  works_for:
+    type: string
+    format: iri-reference
+    description: Organization the person works for (IRI reference)
+    x-oold-range: Organization.schema.json
+</code></pre>
+</div>
+
+</div></aside>
+<p>An OO-LD-aware implementation uses this to read and modify properties that are actually stored in another object: loading an <code>Organization</code> editor prepopulates <code>employees</code> by querying which persons work for it; storing the <code>Organization</code> writes it into each referenced person's <code>works_for</code> field; and removing a person from <code>employees</code> removes the organization from theirs.</p></section><section id="ui-generation" class="informative"><h4>UI Generation</h4><p>OO-LD schemas double as the source for auto-generated forms and views. UI intent is carried in two layers:</p>
 <ul>
 <li>Portable, renderer-agnostic keywords in the <code>x-oold-ui-*</code> vocabulary, defined here. Any form generator can honour them.</li>
 <li>Renderer-specific keywords passed through under a vendor prefix - <code>x-jedison-*</code> for <a href="https://github.com/germanbisurgi/jedison">jedison</a>, the successor of <a href="https://github.com/json-editor/json-editor">json-editor</a> - for options that do not generalize.</li>
@@ -1029,9 +1343,9 @@ intersections (<code>allOf</code>) and inline constraints can be combined to des
 <p>For enum code generation OO-LD keeps the established <code>x-enum-varnames</code> (identifier-safe names aligned with <code>enum</code>) and its companion <code>x-enum-descriptions</code>; these are widely supported vendor extensions (OpenAPI Generator; NSwag's <code>x-enumNames</code>) and are distinct from the human display labels in <code>x-oold-ui-enum-titles</code>.</p>
 <p><code>x-oold-ui-default-property</code> replaces the json-editor <code>defaultProperties</code> array (which listed the optional properties shown initially). That array is <em>extend-only</em> under composition: because composed schemas merge the arrays, a derived schema can add a default property but cannot switch one off. A per-property boolean is <em>overridable</em> - it resolves most-derived-wins (see <a href="#merge-and-override-model"></a>), so a derived schema sets it to <code>false</code> to hide a property a base schema showed. For the same reason <code>x-oold-reverse-default-properties</code> is deprecated in favour of <code>x-oold-ui-default-property</code> on the reverse property.</p></section><section id="widget-hints"><h5>Widget hints: <code>format</code> vs <code>x-oold-ui-widget</code></h5><p><code>format</code> carries the widget hint when its value is a registered JSON Schema 2020-12 format (<code>date</code>, <code>date-time</code>, <code>time</code>, <code>duration</code>, <code>email</code>, <code>uri</code>, <code>iri</code>, <code>uuid</code>, ...); a validator may check it and a form generator picks the matching input. Values that are not registered formats (<code>table</code>, <code>tabs</code>, <code>grid</code>, <code>autocomplete</code>, <code>textarea</code>, <code>checkbox</code>, <code>markdown</code>, <code>color</code>, ...) are widget-only and go in <code>x-oold-ui-widget</code>, leaving <code>format</code> for validation semantics.</p></section><section id="validator-vs-widget" class="informative"><h5>Validator vs. form widget</h5><p>A modern JSON Schema 2020-12 toolchain - ajv, the json-editor / jedison built-in validator, Hyperjump, Pydantic v2, OpenAPI 3.1 - honours <code>const</code> and keywords placed alongside <code>$ref</code>, so OO-LD's composition constructs validate as written; the older assumption that such tooling silently drops them does not hold for these validators. A narrower caveat concerns UI generation rather than validation: a form generator's <em>widget rendering</em> of a keyword may differ from what its <em>validator</em> enforces - for example json-editor validates <code>const</code> but does not necessarily render the field as a fixed value. A consumer restricted to a Draft-4-only JSON Schema processor remains the exception, since keywords adjacent to <code>$ref</code> and <code>const</code> are only guaranteed from later drafts.</p></section><section id="ui-delivery"><h5>Delivery: inline or overlay</h5><p>UI keywords may be embedded in the schema (inline):</p>
 <div class="ex-tabs">
-<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex2j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex2y">View as YAML</button></div>
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex10j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex10y">View as YAML</button></div>
 
-<div class="ex-panel" id="ex2j" role="tabpanel">
+<div class="ex-panel" id="ex10j" role="tabpanel">
 
 <pre><code class="language-json">{
   &quot;$schema&quot;: &quot;https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json&quot;,
@@ -1095,7 +1409,7 @@ intersections (<code>allOf</code>) and inline constraints can be combined to des
 </code></pre>
 </div>
 
-<div class="ex-panel" id="ex2y" role="tabpanel" hidden>
+<div class="ex-panel" id="ex10y" role="tabpanel" hidden>
 
 <pre><code class="language-yaml">$schema: https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json
 $id: UiAnnotations.schema.json
@@ -1178,9 +1492,9 @@ properties:
 
 <p>or applied by an <em>overlay</em> - a separate document that patches a schema without editing it, following the <a href="https://spec.openapis.org/overlay/latest.html">OpenAPI Overlay 1.1.0</a> model. Overlays are a general schema-patching mechanism: the <code>update</code> actions can inject any keywords (semantics, constraints or presentation), and applying <code>x-oold-ui-*</code> annotations is one use case - useful when the schema is generated or owned elsewhere, or when one schema needs different presentation in different contexts. An overlay lists <code>actions</code>, each selecting nodes with an <a href="https://www.rfc-editor.org/rfc/rfc9535">RFC 9535 JSONPath</a> <code>target</code> and merging keys via <code>update</code> (or removing them via <code>remove</code>):</p>
 <div class="ex-tabs">
-<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex3j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex3y">View as YAML</button></div>
+<div class="ex-tablist" role="tablist"><button class="ex-tab" role="tab" aria-selected="true" data-panel="ex11j">JSON</button><button class="ex-tab" role="tab" aria-selected="false" data-panel="ex11y">View as YAML</button></div>
 
-<div class="ex-panel" id="ex3j" role="tabpanel">
+<div class="ex-panel" id="ex11j" role="tabpanel">
 
 <pre><code class="language-json">{
   &quot;overlay&quot;: &quot;1.0.0&quot;,
@@ -1212,7 +1526,7 @@ properties:
 </code></pre>
 </div>
 
-<div class="ex-panel" id="ex3y" role="tabpanel" hidden>
+<div class="ex-panel" id="ex11y" role="tabpanel" hidden>
 
 <pre><code class="language-yaml">overlay: 1.0.0
 info:

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -14,7 +14,7 @@ In general, we want to keep keywords in 'instance' JSON-documents (=> property n
     "name": "schema:name",
     "type": "@type"
   },
-  "x-oold-iri": "ex:RawData",
+  "x-oold-iri": "schema:Person",
   "title": "Person",
   "type": "object",
   "properties": {
@@ -45,7 +45,7 @@ class Person(BaseModel):
                 "name": "schema:name",
                 "type": "@type"
             },
-            "x-oold-iri": "ex:RawData",  # the IRI of the class
+            "x-oold-iri": "schema:Person",  # the IRI of the class
         }
     )
     type: Optional[str] = "schema:Person"

--- a/examples/Organization.schema.json
+++ b/examples/Organization.schema.json
@@ -8,7 +8,8 @@
     "Thing.schema.json",
     {
       "schema": "http://schema.org/",
-      "address": { "@id": "schema:address", "@context": "Address.schema.json" }
+      "address": { "@id": "schema:address", "@context": "Address.schema.json" },
+      "employees": { "@reverse": "schema:worksFor", "@type": "@id" }
     }
   ],
   "title": "Organization",
@@ -20,6 +21,19 @@
       "type": "object",
       "$ref": "Address.schema.json",
       "description": "Postal address of the organization"
+    }
+  },
+  "x-oold-reverse-properties": {
+    "employees": {
+      "type": "array",
+      "title": "Employees",
+      "description": "Persons who work for this organization; stored on each Person as works_for, editable here via JSON-LD @reverse.",
+      "x-oold-ui-default-property": true,
+      "items": {
+        "type": "string",
+        "format": "iri-reference",
+        "x-oold-range": "Person.schema.json"
+      }
     }
   }
 }

--- a/examples/PersonWithPet.instance.json
+++ b/examples/PersonWithPet.instance.json
@@ -1,0 +1,6 @@
+{
+  "@context": "PersonWithPet.schema.json",
+  "$schema": "PersonWithPet.schema.json",
+  "name": "Max",
+  "pets": [ { "name": "Bruno" } ]
+}

--- a/examples/PersonWithPet.schema.json
+++ b/examples/PersonWithPet.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json",
+  "$id": "PersonWithPet.schema.json",
+  "@context": {
+    "ex": "https://example.org/",
+    "schema": "http://schema.org/",
+    "name": "schema:name",
+    "pets": { "@id": "ex:hasPet", "@container": "@set", "@context": "Pet.schema.json" }
+  },
+  "title": "Person with pet",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string", "description": "Name of the person" },
+    "pets": {
+      "type": "array",
+      "description": "Pets owned by the person (embedded via a property-scoped context)",
+      "items": { "$ref": "Pet.schema.json" }
+    }
+  }
+}

--- a/examples/Pet.schema.json
+++ b/examples/Pet.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://oo-ld.github.io/oold-schema/latest/meta/oold-meta-schema.json",
+  "$id": "Pet.schema.json",
+  "@context": {
+    "ex": "https://example.org/",
+    "name": "ex:petName"
+  },
+  "title": "Pet",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string", "description": "Name of the pet" }
+  }
+}

--- a/examples/spec/composition-reflection.json
+++ b/examples/spec/composition-reflection.json
@@ -1,0 +1,17 @@
+{
+  "@context": [
+    "B.schema.json",
+    "P0.schema.json",
+    { "p1": { "@context": "P1.schema.json" } },
+    { "p2": { "@context": ["P2a.schema.json", "P2b.schema.json"] } },
+    { "p3": { "@context": { "keyword_in_P3a": "ex:Property1", "keyword_in_P3b": "ex:Property2" } } }
+  ],
+  "$id": "A.schema.json",
+  "allOf": [ { "$ref": "B.schema.json" } ],
+  "properties": {
+    "p0": { "type": "string", "$ref": "P0.schema.json" },
+    "p1": { "type": "object", "$ref": "P1.schema.json" },
+    "p2": { "type": "object", "allOf": [ { "$ref": "P2a.schema.json" }, { "$ref": "P2b.schema.json" } ] },
+    "p3": { "oneOf": [ { "$ref": "P3a.schema.json" }, { "$ref": "P3b.schema.json" } ] }
+  }
+}

--- a/examples/spec/normalize-input.json
+++ b/examples/spec/normalize-input.json
@@ -1,0 +1,18 @@
+{
+  "@graph": [
+    {
+      "id": "demo:person1",
+      "type": "schema:Person",
+      "name": "Person1",
+      "works_for": "demo:organizationA",
+      "works_for*": "demo:organizationB"
+    },
+    { "id": "demo:organizationA", "type": "schema:Organization" },
+    { "id": "demo:organizationB", "type": "schema:Organization" },
+    {
+      "id": "demo:organizationC",
+      "type": "schema:Organization",
+      "employees": "demo:person1"
+    }
+  ]
+}

--- a/examples/spec/normalize-output.json
+++ b/examples/spec/normalize-output.json
@@ -1,0 +1,13 @@
+{
+  "@graph": [
+    {
+      "id": "demo:organizationA",
+      "type": "schema:Organization",
+      "employees": ["demo:person1", "demo:person2", "demo:person3"],
+      "label": [ { "lang": "en", "text": "organizationA" } ]
+    },
+    { "id": "demo:person1", "type": "schema:Person", "name": "Person1" },
+    { "id": "demo:person2", "type": "schema:Person", "name": "Person2" },
+    { "id": "demo:person3", "type": "schema:Person", "name": "Person3" }
+  ]
+}

--- a/macros.py
+++ b/macros.py
@@ -22,8 +22,76 @@ _LANG_BY_EXT = {
 }
 
 
+_ex_counter = [0]  # unique ids for the spec's tab panels within one render
+
+
+def _json_to_yaml(text):
+    """Convert JSON text to block-style YAML (keys kept in source order), or None
+    if conversion is unavailable. pyyaml is provided by the spec renderer (uv,
+    PEP 723) and the docs build (uvx --with pyyaml); if it is missing, or the
+    text is not a full JSON document, callers fall back to a plain JSON block."""
+    try:
+        import yaml  # noqa: PLC0415 - optional; imported lazily so macros load without it
+    except Exception:
+        return None
+    try:
+        data = json.loads(text)
+    except Exception:
+        return None
+    return yaml.safe_dump(
+        data, sort_keys=False, allow_unicode=True, default_flow_style=False, width=100
+    ).rstrip("\n")
+
+
+def _fence(lang, text):
+    return f"```{lang}\n{text}\n```"
+
+
+def _docs_tabs(json_text, yaml_text):
+    """JSON + 'View as YAML' as pymdownx content tabs (fence + content indented
+    under each tab marker)."""
+    def blk(lang, text):
+        return "\n".join(("    " + ln).rstrip() for ln in [f"```{lang}", *text.split("\n"), "```"])
+    return f'=== "JSON"\n\n{blk("json", json_text)}\n\n=== "View as YAML"\n\n{blk("yaml", yaml_text)}'
+
+
+def _spec_tabs(json_text, yaml_text):
+    """JSON + 'View as YAML' as a small HTML tab widget for the ReSpec spec.
+
+    The code stays in Markdown fences (blank-line separated from the container
+    tags) so mistune still renders them as <pre><code> - keeping ReSpec syntax
+    highlighting and staying out of reach of the RFC 2119 wrapper. Styled and
+    toggled by the CSS/JS injected in scripts/render_spec.py."""
+    _ex_counter[0] += 1
+    n = _ex_counter[0]
+
+    def panel(pid, lang, text, hidden):
+        return f'<div class="ex-panel" id="{pid}" role="tabpanel"{" hidden" if hidden else ""}>\n\n{_fence(lang, text)}\n\n</div>'
+
+    return (
+        '<div class="ex-tabs">\n'
+        '<div class="ex-tablist" role="tablist">'
+        f'<button class="ex-tab" role="tab" aria-selected="true" data-panel="ex{n}j">JSON</button>'
+        f'<button class="ex-tab" role="tab" aria-selected="false" data-panel="ex{n}y">View as YAML</button>'
+        '</div>\n\n'
+        f'{panel(f"ex{n}j", "json", json_text, False)}\n\n'
+        f'{panel(f"ex{n}y", "yaml", yaml_text, True)}\n\n'
+        '</div>'
+    )
+
+
+def _example_tabs(json_text):
+    """Render JSON (main) + 'View as YAML' tabs, or a plain JSON block when YAML
+    conversion is unavailable. Target-aware (docs vs spec)."""
+    yaml_text = _json_to_yaml(json_text)
+    if yaml_text is None:
+        return _fence("json", json_text)
+    return _spec_tabs(json_text, yaml_text) if TARGET == "spec" else _docs_tabs(json_text, yaml_text)
+
+
 def inline_file(path, lang="auto"):
-    """Inline any repo file as a fenced code block.
+    """Inline any repo file. JSON content renders as JSON (main) + 'View as YAML'
+    tabs; other languages stay a single fenced block.
 
     `path` is relative to the repo root (no hardcoded directory prefix). With
     lang="auto" the fence language is inferred from the file extension.
@@ -32,11 +100,11 @@ def inline_file(path, lang="auto"):
         content = fh.read().rstrip("\n")
     if lang == "auto":
         lang = _LANG_BY_EXT.get(os.path.splitext(path)[1].lower(), "")
-    return f"```{lang}\n{content}\n```"
+    return _example_tabs(content) if lang == "json" else _fence(lang, content)
 
 
 def example(name, lang="json"):
-    """Inline an example schema from examples/<name>.schema.json as a code block."""
+    """Inline an example schema (examples/<name>.schema.json) as JSON/YAML tabs."""
     return inline_file(f"examples/{name}.schema.json", lang)
 
 

--- a/scripts/render_spec.py
+++ b/scripts/render_spec.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["mistune==3.3.2", "jinja2>=3,<4"]
+# dependencies = ["mistune==3.3.2", "jinja2>=3,<4", "pyyaml==6.0.2"]
 # ///
 """Render the ReSpec spec docs/spec/index.html from spec/sections/*.md.
 
@@ -170,8 +170,34 @@ def render_index():
     )
 
 
+# Styling + toggle for the JSON / "View as YAML" example tabs emitted by
+# macros._spec_tabs. Kept minimal and dependency-free; injected into <head>.
+TAB_ASSETS = """  <style>
+    .ex-tabs { margin: 1em 0; }
+    .ex-tablist { display: flex; gap: .25rem; border-bottom: 1px solid #ccc; margin-bottom: .5em; }
+    .ex-tab { border: 0; background: none; padding: .3em .8em; cursor: pointer; font: inherit; color: #555; border-bottom: 2px solid transparent; }
+    .ex-tab[aria-selected="true"] { color: #005a9c; border-bottom-color: #005a9c; font-weight: 600; }
+    .ex-panel[hidden] { display: none; }
+  </style>
+  <script>
+    // Toggle the JSON / YAML example tabs (event delegation; runs regardless of ReSpec).
+    document.addEventListener("click", function (e) {
+      var tab = e.target.closest(".ex-tab");
+      if (!tab) return;
+      var group = tab.closest(".ex-tabs");
+      group.querySelectorAll(".ex-tab").forEach(function (b) {
+        b.setAttribute("aria-selected", b === tab ? "true" : "false");
+      });
+      group.querySelectorAll(".ex-panel").forEach(function (p) {
+        p.hidden = (p.id !== tab.dataset.panel);
+      });
+    });
+  </script>"""
+
+
 def render_head():
     respec = json.dumps(cfg.RESPEC, indent=2, ensure_ascii=False)
+    tab_assets = TAB_ASSETS
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -192,6 +218,7 @@ def render_head():
     const schedule = () => setTimeout(runMermaid, 500);  // let ReSpec finish rearranging first
     if (document.readyState === "complete") schedule(); else window.addEventListener("load", schedule);
   </script>
+{tab_assets}
 </head>
 <body>
 <p class="copyright">Copyright &copy; the OO-LD contributors. This document is made available under the <a rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal</a> Public Domain Dedication; W3C liability, trademark and document-license rules do <strong>not</strong> apply.</p>"""

--- a/scripts/spec_config.py
+++ b/scripts/spec_config.py
@@ -52,6 +52,22 @@ RESPEC = {
             "publisher": "IETF",
             "status": "Best Current Practice",
         },
+        "RFC8259": {
+            "title": "The JavaScript Object Notation (JSON) Data Interchange Format",
+            "href": "https://www.rfc-editor.org/rfc/rfc8259",
+            "authors": ["T. Bray"],
+            "date": "December 2017",
+            "publisher": "IETF",
+            "status": "Internet Standard",
+        },
+        "RFC8785": {
+            "title": "JSON Canonicalization Scheme (JCS)",
+            "href": "https://www.rfc-editor.org/rfc/rfc8785",
+            "authors": ["A. Rundgren", "B. Jordan", "S. Erdtman"],
+            "date": "June 2020",
+            "publisher": "IETF",
+            "status": "Informational",
+        },
         "RFC3986": {
             "title": "Uniform Resource Identifier (URI): Generic Syntax",
             "href": "https://www.rfc-editor.org/rfc/rfc3986",

--- a/spec/sections/03-conformance.md
+++ b/spec/sections/03-conformance.md
@@ -3,3 +3,11 @@
 As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
 
 The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in [[!RFC2119]].
+
+### Notation {#notation}
+
+The normative data model of OO-LD is the JSON data model shared by [[JSONSCHEMA]] and [[JSON-LD11]]. JSON ([[RFC8259]]) is the canonical serialization: a conforming OO-LD schema or instance MUST be interchangeable as JSON, and the canonical form used for identity and integrity (for example content-hashing a versioned schema) is its JSON Canonicalization Scheme ([[RFC8785]]) serialization.
+
+A document MAY additionally be authored or served as YAML, provided it stays within the JSON-compatible subset of [YAML 1.2](https://yaml.org/spec/1.2.2/): no tags, anchors, aliases, or merge keys; a single document; and no implicit typing beyond what JSON expresses. Within this subset - the same profile adopted by [YAML-LD](https://github.com/w3c/yaml-ld) - a YAML document maps one-to-one onto the JSON data model and converts to the canonical JSON without loss. YAML outside this subset is NOT a conforming OO-LD serialization.
+
+Authors using YAML should be aware that YAML comments and implicit type coercions (for example the strings `NO` or `1.10` read as a boolean or a truncated number by some parsers) do not survive conversion to the canonical JSON; the JSON form is authoritative. Examples in this specification are shown as JSON, with an equivalent YAML rendering available under "View as YAML".

--- a/spec/sections/06-composition.md
+++ b/spec/sections/06-composition.md
@@ -5,91 +5,33 @@ Composition is how an [=OO-LD schema=] incorporates multiple independent schemas
 It MUST NOT be required to further process an OO-LD schema document in order to interpret it as a JSON-LD context. This implies that all occurrences of `$ref` in the schema are reflected in the JSON-LD context. `$ref` within properties of `type: object` MUST be listed as a scoped JSON-LD context. `$ref` within all other property types and at the root level of the OO-LD schema MUST be listed at the root level of the JSON-LD context. In case of multiple `$ref` within `allOf` the corresponding remote contexts are merged into an array-valued `@context` (see [](#merging-remote-contexts)). For `oneOf` / `anyOf` this requires care to avoid conflicts. At any time the importing OO-LD schema MAY define its own or override the imported JSON-LD context.
 
 :::example{title="Reflecting each `$ref` into the `@context`"}
-```yaml
-"@context":
-  - B.schema.json
-  - P1.schema.json
-  - p1:
-    "@context": P1.schema.json
-  - p2:
-    "@context": 
-      - P2a.schema.json
-      - P2b.schema.json
-  - p3:
-    "@context":
-      keyword_in_P3a: ex:Property1
-      keyword_in_P3b: ex:Property2
-$id: A.schema.json
-allOf:
-  - $ref: B.schema.json
-properties:
-  p0:
-    type: string
-    $ref: P0.schema.json
-  p1:
-    type: object
-    $ref: P1.schema.json
-  p2:
-    type: object
-    allOf:
-      $ref: P2a.schema.json
-      $ref: P2b.schema.json
-  p3:
-    oneOf:
-      $ref: P3a.schema.json
-      $ref: P3b.schema.json
-```
+{{ inline_file('examples/spec/composition-reflection.json') }}
 :::
 
 :::example{title="A nested context and the RDF it produces"}
 A `Pet` schema:
-```yaml
-"@context": 
-  name: ex:petName
-$id: Pet.schema.json
-properties:
-  name:
-    type: string
-```
 
-A `Person` schema that embeds `Pet` under a property-scoped context:
-```yaml
-"@context": 
-  name: schema:name
-  pets:
-    "@id": ex:hasPet
-    "@context": Pet.schema.json
-$id: Person.schema.json
-properties:
-  name:
-    type: string
-  pets:
-    type: array
-    items: 
-      $ref: Pet.schema.json
-```
+{{ example('Pet') }}
+
+A `PersonWithPet` schema that embeds `Pet` under a property-scoped context:
+
+{{ example('PersonWithPet') }}
 
 An instance:
-```yaml
-"@context": Person.schema.json
-$schema: Person.schema.json
-name: Max
-pets:
-  - name: Bruno
-```
 
-Referencing `Person.schema.json` as the context is equivalent to inlining the reflected contexts:
-```yaml
-"@context": 
-  name: schema:name
-  pets:
-    "@id": ex:hasPet
-    "@context":
-      name: ex:petName
-$schema: Person.schema.json
-name: Max
-pets:
-  - name: Bruno
+{{ inline_file('examples/PersonWithPet.instance.json') }}
+
+Referencing `PersonWithPet.schema.json` as the context is equivalent to inlining the reflected contexts:
+```json
+{
+  "@context": {
+    "name": "schema:name",
+    "pets": { "@id": "ex:hasPet", "@context": { "name": "ex:petName" } }
+  },
+  "$schema": "PersonWithPet.schema.json",
+  "name": "Max",
+  "pets": [ { "name": "Bruno" } ]
+}
 ```
 
 which expands (via the reflected contexts) to the RDF:
@@ -144,14 +86,15 @@ This single model governs every place OO-LD collapses composition into a resolve
 Because `allOf` composition is conjunctive, `additionalProperties: false` on one subschema rejects the members that the other composed subschemas contribute, so it cannot close a composed object. To close such an object - rejecting members that no composed subschema declares - use `unevaluatedProperties: false` ([[JSONSCHEMA]] §11.3), which is evaluated after the `allOf` branches and therefore accounts for their properties. A schema closed this way should still allow the instance-level `$schema` and `@context` members (see [](#schema-instances)).
 
 :::example{title="Closing an inherited object with `unevaluatedProperties`"}
-```yaml
-$id: Employee.schema.json
-allOf:
-  - $ref: Person.schema.json
-properties:
-  employeeId:
-    type: string
-unevaluatedProperties: false
+```json
+{
+  "$id": "Employee.schema.json",
+  "allOf": [ { "$ref": "Person.schema.json" } ],
+  "properties": {
+    "employeeId": { "type": "string" }
+  },
+  "unevaluatedProperties": false
+}
 ```
 An instance may carry the `Person` properties, `employeeId`, and `$schema` / `@context`; any other member is rejected.
 :::

--- a/spec/sections/07-schema-instances.md
+++ b/spec/sections/07-schema-instances.md
@@ -6,9 +6,11 @@ An [=OO-LD instance=] is a JSON document that conforms to an [=OO-LD schema=]. I
 - `$schema` - the schema URL, identifying the schema the instance is intended to validate against.
 
 :::example{title="An instance referencing its schema"}
-```yaml
-"@context": https://example.org/my-package/1.0.0/Person.schema.json
-$schema: https://example.org/my-package/1.0.0/Person.schema.json
+```json
+{
+  "@context": "https://example.org/my-package/1.0.0/Person.schema.json",
+  "$schema": "https://example.org/my-package/1.0.0/Person.schema.json"
+}
 ```
 :::
 
@@ -113,16 +115,17 @@ A property whose value denotes another resource takes one of three forms in an i
 - an **embedded object** - a nested object with its own properties and no independent identity, e.g. `{ "type": "PostalAddress", "streetAddress": "..." }`, which becomes a blank node.
 
 :::example{title="One `address` property, three value forms"}
+Literal:
 ```json
-{
-  "address": "Mainstreet 1, 10115 Example City"
-}
-{
-  "address": { "id": "https://example.org/address/A1" }
-}
-{
-  "address": { "type": "PostalAddress", "streetAddress": "Mainstreet 1", "postalCode": "10115" }
-}
+{ "address": "Mainstreet 1, 10115 Example City" }
+```
+Reference (by `id`/`@id`):
+```json
+{ "address": { "id": "https://example.org/address/A1" } }
+```
+Embedded object:
+```json
+{ "address": { "type": "PostalAddress", "streetAddress": "Mainstreet 1", "postalCode": "10115" } }
 ```
 :::
 

--- a/spec/sections/08-identification-versioning.md
+++ b/spec/sections/08-identification-versioning.md
@@ -5,17 +5,21 @@
 OO-LD schemas MUST have a `$id` ([[JSONSCHEMA]] §8.2.1) which works as a global and unique identifier of the schema. The value of `$id` MAY be an absolute URI (details below). The schema SHOULD be resolvable via this URI. The schema SHOULD have an annotation `x-oold-uuid` with a UUID value.
 
 :::example{title="A schema `$id` and its `x-oold-uuid`"}
-```yaml
-$id: https://example.org/Foo.schema.json
-x-oold-uuid: b5203131-7321-46bb-8a11-acb3d1015840
-title: Foo
+```json
+{
+  "$id": "https://example.org/Foo.schema.json",
+  "x-oold-uuid": "b5203131-7321-46bb-8a11-acb3d1015840",
+  "title": "Foo"
+}
 ```
 
 It is recommended to use the UUID also in the `$id`:
-```yaml
-$id: https://example.org/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
-x-oold-uuid: b5203131-7321-46bb-8a11-acb3d1015840
-title: Foo
+```json
+{
+  "$id": "https://example.org/b5203131-7321-46bb-8a11-acb3d1015840.schema.json",
+  "x-oold-uuid": "b5203131-7321-46bb-8a11-acb3d1015840",
+  "title": "Foo"
+}
 ```
 :::
 
@@ -27,11 +31,13 @@ title: Foo
 - `x-oold-instance-rdf-type` - the `rdf:type`s that instances carry on export (see [](#semantic-type)). These are stamped onto instance data; `x-oold-iri` describes the schema itself.
 
 :::example{title="Distinguishing document URL, ontology class, and instance type"}
-```yaml
-$id: https://example.org/my-package/1.0.0/Person.schema.json
-x-oold-iri: https://schema.org/Person
-x-oold-instance-rdf-type: ["schema:Person"]
-title: Person
+```json
+{
+  "$id": "https://example.org/my-package/1.0.0/Person.schema.json",
+  "x-oold-iri": "https://schema.org/Person",
+  "x-oold-instance-rdf-type": ["schema:Person"],
+  "title": "Person"
+}
 ```
 :::
 
@@ -44,12 +50,14 @@ OO-LD-aware tooling uses `x-oold-iri` to anchor the schema in an ontology graph,
 The schema version SHOULD be indicated by `x-oold-version`; a prior version MAY be indicated with `x-oold-prior-version`:
 
 :::example{title="Version annotations"}
-```yaml
-$id: https://example.org/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
-x-oold-uuid: b5203131-7321-46bb-8a11-acb3d1015840
-title: Foo
-x-oold-version: 1.1.0
-x-oold-prior-version: 1.0.0
+```json
+{
+  "$id": "https://example.org/b5203131-7321-46bb-8a11-acb3d1015840.schema.json",
+  "x-oold-uuid": "b5203131-7321-46bb-8a11-acb3d1015840",
+  "title": "Foo",
+  "x-oold-version": "1.1.0",
+  "x-oold-prior-version": "1.0.0"
+}
 ```
 :::
 
@@ -64,42 +72,48 @@ Since a package combines multiple schemas, the package version does in general n
 Schemas MAY indicate explicit backward-compatibility with `x-oold-backward-compatible-with` and `x-oold-incompatible-with`:
 
 :::example{title="Declaring backward-compatibility"}
-```yaml
-$id: https://example.org/my-package/2.1.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
-x-oold-uuid: b5203131-7321-46bb-8a11-acb3d1015840
-title: Foo
-x-oold-version: 1.1.0
-x-oold-prior-version: 1.0.0
-x-oold-backward-compatible-with: https://example.org/my-package/2.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
-x-oold-incompatible-with: https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
+```json
+{
+  "$id": "https://example.org/my-package/2.1.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json",
+  "x-oold-uuid": "b5203131-7321-46bb-8a11-acb3d1015840",
+  "title": "Foo",
+  "x-oold-version": "1.1.0",
+  "x-oold-prior-version": "1.0.0",
+  "x-oold-backward-compatible-with": "https://example.org/my-package/2.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json",
+  "x-oold-incompatible-with": "https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json"
+}
 ```
 :::
 
 Schemas within a package or package repository MAY use relative URIs ([[RFC3986]] §5.1). For example, `A.schema.json` referenced from `https://raw.githubusercontent.com/MyOrg/my-package/refs/heads/2.0.0/`:
 
 :::example{title="Relative `$ref` inside a package"}
-```yaml
-$id: B.schema.json
-title: Foo
-allOf:
-  - $ref: A.schema.json
+```json
+{
+  "$id": "B.schema.json",
+  "title": "Foo",
+  "allOf": [ { "$ref": "A.schema.json" } ]
+}
 ```
 
 expands to:
-```yaml
-$id: https://raw.githubusercontent.com/MyOrg/my-package/refs/heads/2.0.0/B.schema.json
-title: Foo
-allOf:
-  - $ref: https://raw.githubusercontent.com/MyOrg/my-package/refs/heads/2.0.0/A.schema.json
+```json
+{
+  "$id": "https://raw.githubusercontent.com/MyOrg/my-package/refs/heads/2.0.0/B.schema.json",
+  "title": "Foo",
+  "allOf": [ { "$ref": "https://raw.githubusercontent.com/MyOrg/my-package/refs/heads/2.0.0/A.schema.json" } ]
+}
 ```
 :::
 
 Instance documents SHOULD always use a versioned schema URL to make clear which schema version they comply with:
 
 :::example{title="An instance pinned to a schema version"}
-```yaml
-"@context": https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
-$schema: https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json
+```json
+{
+  "@context": "https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json",
+  "$schema": "https://example.org/my-package/1.0.0/b5203131-7321-46bb-8a11-acb3d1015840.schema.json"
+}
 ```
 :::
 

--- a/spec/sections/09-extensions.md
+++ b/spec/sections/09-extensions.md
@@ -48,45 +48,13 @@ _:b0 <schema:name> "test" .
 The notation can also drive data transformation and normalization. For example, a dataset in which persons and organizations report their relations in a syntactically non-interoperable way can be normalized into a consistent unified dataset (see [OO-LD/oold-schema#11](https://github.com/OO-LD/oold-schema/issues/11)).
 
 :::example{title="Normalizing a syntactically non-interoperable dataset"}
-Input - the same relation is reported in three different ways (`works_for`, a distinct `works_for*`, and a backward `employees`):
-```yaml
-"@graph":
-- id: demo:person1
-  type: schema:Person
-  name: Person1
-  works_for: demo:organizationA # forward relation
-  works_for*: demo:organizationB # forward relation but different property
-- id: demo:organizationA
-  type: schema:Organization
-- id: demo:organizationB
-  type: schema:Organization
-- id: demo:organizationC
-  type: schema:Organization
-  employees: demo:person1 # backwards relation
-```
+Input - the same relation is reported in three different ways: a forward `works_for`, a distinct forward `works_for*`, and a backward `employees`:
+
+{{ inline_file('examples/spec/normalize-input.json') }}
 
 Normalized - a single, consistent representation:
-```yaml
-"@graph":
-- employees:
-  - demo:person1
-  - demo:person2
-  - demo:person3
-  id: demo:organizationA
-  label:
-  - lang: en
-    text: organizationA
-  type: schema:Organization
-- id: demo:person1
-  name: Person1
-  type: schema:Person
-- id: demo:person2
-  name: Person2
-  type: schema:Person
-- id: demo:person3
-  name: Person3
-  type: schema:Person
-```
+
+{{ inline_file('examples/spec/normalize-output.json') }}
 :::
 
 #### Term mappings and synonyms (`x-oold-context`) {#synonyms}
@@ -363,11 +331,16 @@ intersections (`allOf`) and inline constraints can be combined to describe an an
 
 :::example{title="Range as a subschema (Organization located in Germany)"}
 ```json
-"x-oold-range": {
-  "allOf": [
-    { "x-oold-ref": "Organization.schema.json" },
-    { "properties": { "address": { "properties": { "country": { "const": "DE" } } } } }
-  ]
+{
+  "works_for": {
+    "type": "string",
+    "x-oold-range": {
+      "allOf": [
+        { "x-oold-ref": "Organization.schema.json" },
+        { "properties": { "address": { "properties": { "country": { "const": "DE" } } } } }
+      ]
+    }
+  }
 }
 ```
 :::
@@ -395,65 +368,22 @@ The value of an IRI-valued property is a JSON string. Its role as a reference co
 
 #### Reverse properties {#reverse-properties}
 
-Many relations are symmetric (e.g. Organization employs Person ⇔ Person works for Organization) and users want to edit them from both sides, without storing the information twice. The keywords `x-oold-reverse-properties` and `x-oold-reverse-required` declare such a [=reverse property=], mapped with JSON-LD `@reverse` in the `@context`. (The earlier `x-oold-reverse-default-properties` array is deprecated: mark a reverse property shown by default with `x-oold-ui-default-property` on the property itself - see [](#ui-generation) - which, unlike the merged array, is overridable under composition.) To make `employees` the reverse of `organization`:
+Many relations are symmetric (e.g. Organization employs Person ⇔ Person works for Organization) and users want to edit them from both sides, without storing the information twice. The keywords `x-oold-reverse-properties` and `x-oold-reverse-required` declare such a [=reverse property=], mapped with JSON-LD `@reverse` in the `@context`. (The earlier `x-oold-reverse-default-properties` array is deprecated: mark a reverse property shown by default with `x-oold-ui-default-property` on the property itself - see [](#ui-generation) - which, unlike the merged array, is overridable under composition.) To make `employees` the reverse of `works_for`:
 
-- define `employees` in `x-oold-reverse-properties` of `Organization`;
-- define `organization` in the `properties` of `Person`;
-- map `organization` to a semantic property, e.g. `schema:worksFor`, in the `@context` of `Person`;
-- map `employees` with `@reverse` to the same property in the `@context` of `Organization` ([[JSON-LD11]] reverse properties).
+- define `works_for` in the `properties` of `Person`, mapped to a semantic property (`schema:worksFor`) in the `@context` of `Person`;
+- define `employees` in `x-oold-reverse-properties` of `Organization`, mapped with `@reverse` to the same property in the `@context` of `Organization` ([[JSON-LD11]] reverse properties).
 
 :::example{title="Reverse property across two schemas"}
-`Organization.schema.json`:
-```json
-{
-  "@context": [
-    { "employees": { "@reverse": "schema:worksFor", "@type": "@id" } }
-  ],
-  "title": "Organization",
-  "type": "object",
-  "required": ["type"],
-  "x-oold-reverse-required": [],
-  "x-oold-reverse-properties": {
-    "employees": {
-      "type": "array",
-      "title": "Employees",
-      "x-oold-ui-default-property": true,
-      "items": {
-        "type": "string",
-        "format": "autocomplete",
-        "title": "Person",
-        "x-oold-range": "Person.schema.json"
-      }
-    }
-  }
-}
-```
+`Organization.schema.json` declares `employees` as the reverse property (the `address` composition and `Thing` inheritance are unrelated to this demonstration):
 
-`Person.schema.json`:
-```json
-{
-  "@context": [
-    { "organization": { "@id": "schema:worksFor", "@type": "@id" } }
-  ],
-  "title": "Person",
-  "defaultProperties": ["organization"],
-  "properties": {
-    "organization": {
-      "title": "Organization",
-      "description": "Organization(s) the person is affiliated with. E.g., university, research institute, company, etc.",
-      "type": "array",
-      "items": {
-        "type": "string",
-        "format": "autocomplete",
-        "x-oold-range": "Organization.schema.json"
-      }
-    }
-  }
-}
-```
+{{ example('Organization') }}
+
+`Person.schema.json` carries the forward `works_for` property:
+
+{{ example('Person') }}
 :::
 
-An OO-LD-aware implementation uses this to read and modify properties that are actually stored in another object: loading an `Organization` editor prepopulates `employees` by querying which persons work for it; storing the `Organization` writes it into each referenced person's `organization` field; and removing a person from `employees` removes the organization from theirs.
+An OO-LD-aware implementation uses this to read and modify properties that are actually stored in another object: loading an `Organization` editor prepopulates `employees` by querying which persons work for it; storing the `Organization` writes it into each referenced person's `works_for` field; and removing a person from `employees` removes the organization from theirs.
 
 #### UI Generation {#ui-generation .informative}
 


### PR DESCRIPTION
Addresses the JSON-vs-YAML notation question (#96): make JSON the normative/canonical notation while offering YAML as a human-facing rendering, and stop mixing the two ad hoc.

## Notation policy (normative)
New **Notation** section in `03-conformance`: the JSON data model (shared by JSON Schema + JSON-LD) is canonical; JSON is the required interchange serialization and the JCS ([[RFC8785]]) form is authoritative for identity/hashing. YAML is permitted **only** within the JSON-compatible YAML 1.2 subset (no tags/anchors/aliases/merge-keys, single document, no implicit typing beyond JSON) - the same profile as YAML-LD - so it round-trips 1:1. Caveats (implicit typing, comments not preserved) are called out. A short non-normative note mirrors this in the docs (`get-started`).

## Example rendering: JSON main + "View as YAML" tab
File-backed examples (`{{ example() }}` / `{{ inline_file() }}`) now render as a **JSON (main) + "View as YAML"** tab pair. The YAML is generated from the example JSON at render time (pyyaml, block style, key order preserved), so it's single-source and always 1:1.
- **Docs**: native `pymdownx.tabbed` content tabs (already enabled).
- **Spec (ReSpec)**: a small HTML/JS tab widget; the code stays in Markdown fences (blank-line separated) so mistune still emits `<pre><code>` - keeping ReSpec syntax highlighting and staying clear of the RFC 2119 wrapper. CSS/JS injected in `render_head()`.
- `pyyaml` pinned in the renderer (PEP 723) and added to the zensical/mike `uvx` invocations (Makefile + CI) so both renderers can generate the YAML.

## Deferred (needs your call)
The substantial **inline** JSON examples were evaluated for promotion to file-backed (so they'd get tabs too), but they're prose-coupled variants: the reverse/composition `Organization`/`Person` blocks clash with the canonical `examples/*.schema.json` (different simplified content), and others are fragments, not standalone schemas. I left them inline rather than pollute the canonical `examples/` set or risk validation. Options for a follow-up: leave as-is, move to an `examples/illustrations/` dir loaded via `inline_file`, or auto-wrap all ```json blocks. The YAML-authored sections (`06`, `08`) are a separate consistency pass.

Verified: `check_spec` OK (52 sections; new `#notation` anchor + RFC 8259/8785 refs resolve), `npm run validate` passes, `zensical build` clean, tabs render in both the spec and the docs. Refs #96.