### PR TITLE
Expose the validation harness as a reusable oold-validate CLI

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -30,7 +30,13 @@ The [`oold-schema`](https://github.com/OO-LD/oold-schema) repository ships a val
 
 ### General workflow (any schema, no fixtures)
 
-These run on every schema and instance in [`examples/`](https://github.com/OO-LD/oold-schema/tree/main/examples) with no per-schema test data, so they apply to any OO-LD schema you write:
+These run on every schema and instance in [`examples/`](https://github.com/OO-LD/oold-schema/tree/main/examples) with no per-schema test data, so they apply to any OO-LD schema you write. They are also **reusable on your own schemas**: the harness is exposed as an `oold-validate` CLI, so a downstream repo can conformance-check its generated schemas against this exact pipeline without copying it -
+
+```
+npx --yes github:OO-LD/oold-schema oold-validate path/to/schemas
+```
+
+Given a directory argument, `oold-validate <dir>` runs only the general-workflow tier below (well-formedness, auto-generated instance, branch iteration, RDF roundtrip, pattern lint) over that directory's `*.schema.json`, using this package's meta-schemas; the deterministic per-feature suites and vocabulary coverage stay scoped to this repo's own `examples/`. The checks are:
 
 - **Well-formedness** - the schema validates against the OO-LD meta-schema and its `$ref` composition resolves.
 - **Auto-generated instance** - an instance is generated (via [json-schema-faker](https://github.com/json-schema-faker/json-schema-faker), all properties, declared `format`s respected) and must validate against the schema; this catches unsatisfiable schemas.

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "private": true,
   "type": "module",
   "description": "OO-LD schema specification and validation tooling",
+  "bin": {
+    "oold-validate": "scripts/validate.mjs"
+  },
   "scripts": {
     "validate": "node scripts/validate.mjs",
     "extract-legacy": "node scripts/extract-legacy-keywords.mjs"
   },
-  "devDependencies": {
+  "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.0.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^3.0.1",

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1,3 +1,9 @@
+#!/usr/bin/env node
+// With no argument this validates this package's own examples/ (full two-tier suite). Given a
+// directory argument (`oold-validate <dir>`) it validates that directory's *.schema.json with
+// the general-workflow tier only - so a downstream repo can conformance-check its generated
+// schemas with the upstream pipeline. The meta-schemas always come from this package.
+//
 // Validates the OO-LD example schemas and instances, fully offline:
 //   1. the meta-schema is valid against JSON-Schema 2020-12 (ajv validates it on compile);
 //   2. each example schema is a well-formed OO-LD schema (validated against the meta-schema)
@@ -24,10 +30,13 @@ import { schemaToFrame, embeddedProperties, instanceRdfTypes } from "./schema_to
 import { arrayPropertiesMissingContainer, iriReferencesMissingFormat } from "./pattern_lint.mjs";
 import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const exDir = join(root, "examples");
+// Target schema directory: a CLI argument (an external repo's schemas) or, by default, this
+// package's own examples/. Meta-schemas are always loaded from this package (below).
+const targetArg = process.argv[2];
+const exDir = targetArg ? resolve(process.cwd(), targetArg) : join(root, "examples");
 const meta = JSON.parse(readFileSync(join(root, "meta", "oold-meta-schema.json"), "utf8"));
 const uiMeta = JSON.parse(readFileSync(join(root, "meta", "oold-ui-meta-schema.json"), "utf8"));
 const patternLint = JSON.parse(readFileSync(join(root, "meta", "oold-pattern-lint.schema.json"), "utf8"));
@@ -357,7 +366,7 @@ const complianceFiles = (() => { try { return readdirSync(complianceDir).filter(
 const RDF_BASE = "https://oo-ld.test/";
 const coveredKeywords = new Set();
 
-console.log("\nCompliance suite (deterministic, per feature):");
+if (complianceFiles.length) console.log("\nCompliance suite (deterministic, per feature):");
 for (const file of complianceFiles) {
   const groups = JSON.parse(readFileSync(join(complianceDir, file), "utf8"));
   for (const group of groups) {
@@ -437,15 +446,19 @@ for (const file of complianceFiles) {
   }
 }
 
-// vocab coverage: every keyword defined in the meta-schemas must have a well-formedness test
-console.log("\nVocab coverage (meta-schema keywords vs oold-vocab.json):");
-const definedKeywords = [
-  ...Object.keys(meta.properties).filter((k) => k.startsWith("x-oold-")),
-  ...Object.keys(uiMeta.$defs.keywords.properties),
-];
-const uncovered = definedKeywords.filter((k) => !coveredKeywords.has(k));
-if (!uncovered.length) ok(`all ${definedKeywords.length} x-oold-* / x-oold-ui-* keywords are covered`);
-else bad(`UNCOVERED  ${uncovered.length} keyword(s) defined in the meta-schemas but not tested: ${uncovered.join(", ")}`);
+// vocab coverage: every keyword defined in the meta-schemas must have a well-formedness test.
+// This cross-checks the compliance fixtures, so it only applies to self-validation (a target
+// directory without a compliance/ suite is not expected to cover the vocabulary).
+if (complianceFiles.length) {
+  console.log("\nVocab coverage (meta-schema keywords vs oold-vocab.json):");
+  const definedKeywords = [
+    ...Object.keys(meta.properties).filter((k) => k.startsWith("x-oold-")),
+    ...Object.keys(uiMeta.$defs.keywords.properties),
+  ];
+  const uncovered = definedKeywords.filter((k) => !coveredKeywords.has(k));
+  if (!uncovered.length) ok(`all ${definedKeywords.length} x-oold-* / x-oold-ui-* keywords are covered`);
+  else bad(`UNCOVERED  ${uncovered.length} keyword(s) defined in the meta-schemas but not tested: ${uncovered.join(", ")}`);
+}
 
 console.log(`\n${total - failures}/${total} checks passed${warnings ? `, ${warnings} warning(s)` : ""}`);
 process.exit(failures ? 1 : 0);


### PR DESCRIPTION
## Summary

Makes the validation harness reusable so downstream repos can conformance-check their OO-LD schemas against this exact pipeline, rather than re-implementing it. Concrete step toward #91.

- `scripts/validate.mjs` now takes an optional target directory. With no argument it validates this package's own `examples/` (the full two-tier suite - unchanged, `make check` stays green). Given a directory it runs the **general-workflow tier** (meta-schema well-formedness, pattern lint, auto-generated-instance round-trip with re-validation, `@context`-as-remote-context, branch coverage) over that directory's `*.schema.json`, always using this package's meta-schemas. The deterministic per-feature suites and vocabulary coverage stay scoped to `examples/`.
- Adds the `oold-validate` bin and moves the validator's runtime deps to `dependencies`, so:

  ```
  npx --yes github:OO-LD/oold-schema oold-validate path/to/schemas
  ```

  works from any repo. `docs/tooling.md` documents this.

## Verify

- `make check` - unchanged, green (self-validation runs the full suite).
- `node scripts/validate.mjs <external-dir>` - runs the general tier only over that dir; compliance/vocab correctly skipped when there is no `compliance/` subdir.
