### PR TITLE
Validator: structural embed detection + real-world round-trip hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^3.0.1",
     "ajv-formats-draft2019": "^1.6.1",
-    "json-schema-faker": "^0.6.2",
+    "json-schema-faker": "0.6.2",
     "jsonld": "^8.3.2"
   }
 }

--- a/scripts/schema_to_frame.mjs
+++ b/scripts/schema_to_frame.mjs
@@ -36,9 +36,26 @@ export function contextTerms(context, out = {}) {
 }
 
 // Properties that embed an object: their @context term carries a scoped @context.
+// Properties that embed an object, detected from the JSON Schema shape - a property whose
+// value (or array items, or an anyOf/oneOf branch) is an object with its own properties or a
+// $ref to a type. A scoped @context is a strong signal too, but it is not mandatory (an
+// embed can be mapped by the ambient/top-level context), so shape is the primary signal.
 export function embeddedProperties(schema) {
+  const isEmbed = (node) => {
+    if (!node || typeof node !== "object") return false;
+    if ("$ref" in node) return true;
+    if (node.type === "object" && node.properties) return true;
+    if (node.items) return isEmbed(node.items);
+    for (const kw of ["anyOf", "oneOf", "allOf"]) {
+      if (Array.isArray(node[kw]) && node[kw].some(isEmbed)) return true;
+    }
+    return false;
+  };
+  const props = schema.properties || {};
+  const structural = Object.keys(props).filter((k) => isEmbed(props[k]));
   const terms = contextTerms(schema["@context"]);
-  return Object.keys(terms).filter((t) => "@context" in terms[t]);
+  const scoped = Object.keys(terms).filter((t) => "@context" in terms[t]);
+  return [...new Set([...structural, ...scoped])];
 }
 
 // The instance rdf:type(s) a schema declares. Composition is most-derived-wins

--- a/scripts/schema_to_frame.mjs
+++ b/scripts/schema_to_frame.mjs
@@ -41,9 +41,11 @@ export function contextTerms(context, out = {}) {
 // $ref to a type. A scoped @context is a strong signal too, but it is not mandatory (an
 // embed can be mapped by the ambient/top-level context), so shape is the primary signal.
 export function embeddedProperties(schema) {
+  // An embed is an *object* value: type "object" with its own properties. A $ref alone is not
+  // enough - it may point at a scalar DataType leaf (a literal, not an embed) - and after
+  // dereferencing a real embed is inlined as such an object anyway.
   const isEmbed = (node) => {
     if (!node || typeof node !== "object") return false;
-    if ("$ref" in node) return true;
     if (node.type === "object" && node.properties) return true;
     if (node.items) return isEmbed(node.items);
     for (const kw of ["anyOf", "oneOf", "allOf"]) {
@@ -51,7 +53,15 @@ export function embeddedProperties(schema) {
     }
     return false;
   };
-  const props = schema.properties || {};
+  // Properties may live in allOf members (a dereferenced subclass chain inlines each
+  // superclass as an allOf entry), so collect the full composed property map.
+  const collectProps = (node, out = {}) => {
+    if (!node || typeof node !== "object") return out;
+    for (const [k, v] of Object.entries(node.properties || {})) if (!(k in out)) out[k] = v;
+    for (const sub of node.allOf || []) collectProps(sub, out);
+    return out;
+  };
+  const props = collectProps(schema);
   const structural = Object.keys(props).filter((k) => isEmbed(props[k]));
   const terms = contextTerms(schema["@context"]);
   const scoped = Object.keys(terms).filter((t) => "@context" in terms[t]);

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -69,10 +69,6 @@ const validateAsOOLD = ajv.compile(meta); // also validates the meta-schema agai
 // SHOULD-level round-trip pattern lint over a schema's @context (no @type: xsd:string, ...).
 const validatePatternLint = ajv.compile(patternLint);
 
-// json-schema-faker respects declared string formats (it emits a valid uri/iri/email/...),
-// so generated instances are validated with formats on, matching the committed instances.
-const jsfGen = createGenerator({ alwaysFakeOptionals: true, useExamplesValue: true, useDefaultValue: true, maxItems: 1, maxLength: 40 });
-
 // Compile a dereferenced example schema into a plain instance-validator. The custom $schema
 // (the OO-LD meta URL) is dropped so ajv uses the 2020-12 dialect; x-oold-* keywords are
 // unknown to ajv and ignored (strict:false), which is the intended validator/UI split.
@@ -91,13 +87,37 @@ const derefCache = {};
 // counting it would cut inherited property constraints (turning them permissive) on any
 // schema a few subclass levels deep.
 //
-// The cut is not {}: an empty schema lets the faker emit null / [] / junk-typed values,
-// which JSON-LD drops or mis-keys, producing false RT-LOSSY/RT-ERROR reports. But it must
-// stay permissive for validation: the same (shared) node can be reached intact via another
-// path, so a typed cut would reject legitimate values. `default` does both - it constrains
-// nothing, while the faker (useDefaultValue) emits the harmless marker string instead of
-// random junk, so samples stay lossless and reconstruction re-validates.
-const CUT_SCHEMA = { default: "x-oold-cut" };
+// The cut must stay permissive for validation (a typed cut would reject legitimate values at a
+// node shared with an intact path). It carries only a custom `format`, which two properties
+// exploit:
+//  - ajv (strict:false, validateFormats:true) has no assertion for an unknown format and the
+//    node declares no `type`, so it accepts any value - the required permissiveness.
+//  - json-schema-faker treats a `format` node as a string and, via the `formats` option below,
+//    emits a deterministic marker string for it. This matters because for a *typeless* node
+//    the faker instead picks a random type, so at a permissive cut it would emit booleans /
+//    numbers as often as strings - and a non-string under an `@type:"@id"` term becomes an RDF
+//    literal that cannot compact back under that term, a false round-trip loss. Forcing a
+//    string is safe: it round-trips under any term (an IRI reference under @id, a literal under
+//    a plain term). A unique per-call counter keeps distinct @id-coerced cuts from collapsing
+//    into one RDF node. (The `formats` option is the supported custom-format hook in this faker
+//    version - the top-level registerFormat()/define() do not apply to createGenerator; the
+//    version is pinned so this documented behavior is stable.)
+const CUT_SCHEMA = { format: "x-oold-cut" };
+let cutCounter = 0;
+// Custom faker format generators. `x-oold-cut` renders the cut marker (see above). The others
+// cover formats this faker version has no built-in generator for (its built-ins are date-time,
+// email, uri, hostname, ipv4/ipv6, uuid, json-pointer) - without them the faker emits a plain
+// random string that fails the corresponding ajv format assertion, a false satisfiability
+// failure. Each value is a canonical, ajv-accepted lexical form.
+const jsfGen = createGenerator({
+  alwaysFakeOptionals: true, useExamplesValue: true, useDefaultValue: true, maxItems: 1, maxLength: 40,
+  formats: {
+    "x-oold-cut": () => `https://oo-ld.test/cut/${cutCounter++}`,
+    duration: () => "P1DT2H",
+    date: () => "2020-01-02",
+    time: () => "03:04:05Z",
+  },
+});
 // JSON Schema keywords whose value (or whose members' values) describes a nested instance
 // level; descending into them consumes depth budget. Everything else (composition, $defs,
 // annotations, @context) is depth-neutral.
@@ -416,8 +436,7 @@ const genSamples = {};
 for (const f of schemaFiles) {
   try {
     const schema = await dereffed(f);
-    let sample = jsfGen.generate(schema);
-    if (sample && typeof sample.then === "function") sample = await sample;
+    const sample = await jsfGen.generate(schema);
     uniquifyIds(sample);
     genSamples[f] = sample;
     const validate = compileValidator(schema);
@@ -502,8 +521,7 @@ for (const f of schemaFiles) {
   for (const v of variants) {
     variantChecks++;
     try {
-      let sample = jsfGen.generate(v.schema);
-      if (sample && typeof sample.then === "function") sample = await sample;
+      const sample = await jsfGen.generate(v.schema);
       uniquifyIds(sample);
       if (!validate(sample)) { bad(`VARIANT    ${f} ${v.label}: generated instance rejected: ` + JSON.stringify(validate.errors)); continue; }
       const { lost, restored } = await roundtrip(schema, sample, BASE + f);

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -82,30 +82,76 @@ const derefCache = {};
 // graph with circular object references, and one where many properties share the same
 // referenced leaf/embed nodes. Faker, ajv and the variant walker would recurse without bound
 // on the cycles. boundSchema returns a finite, acyclic copy: a node on the current path (a
-// cycle) or deeper than maxDepth becomes {} (permissive), and shared nodes are memoized so
-// the DAG is not unrolled into an exponentially larger tree. Non-cyclic, shallow schemas
-// (this repo's examples) are copied unchanged.
+// cycle) or beyond maxDepth instance levels is cut, and shared nodes are memoized so the DAG
+// is not unrolled into an exponentially larger tree. Non-cyclic, shallow schemas (this
+// repo's examples) are copied unchanged.
+//
+// Depth counts *instance* nesting (properties/items/... descent), not raw JSON nesting: an
+// allOf/anyOf hop or a subclass chain adds JSON depth without nesting the instance, and
+// counting it would cut inherited property constraints (turning them permissive) on any
+// schema a few subclass levels deep.
+//
+// The cut is not {}: an empty schema lets the faker emit null / [] / junk-typed values,
+// which JSON-LD drops or mis-keys, producing false RT-LOSSY/RT-ERROR reports. But it must
+// stay permissive for validation: the same (shared) node can be reached intact via another
+// path, so a typed cut would reject legitimate values. `default` does both - it constrains
+// nothing, while the faker (useDefaultValue) emits the harmless marker string instead of
+// random junk, so samples stay lossless and reconstruction re-validates.
+const CUT_SCHEMA = { default: "x-oold-cut" };
+// JSON Schema keywords whose value (or whose members' values) describes a nested instance
+// level; descending into them consumes depth budget. Everything else (composition, $defs,
+// annotations, @context) is depth-neutral.
+const INSTANCE_KEYWORDS = new Set(["items", "additionalItems", "additionalProperties", "contains", "propertyNames", "unevaluatedItems", "unevaluatedProperties"]);
+const INSTANCE_MAP_KEYWORDS = new Set(["properties", "patternProperties"]);
 function boundSchema(root, maxDepth = 6) {
+  const cut = () => JSON.parse(JSON.stringify(CUT_SCHEMA));
+  // Pass 1: each node's minimum instance depth over all paths reaching it (0-1 BFS: an
+  // instance-keyword descent costs 1, anything else 0). A shared node is then cut (or kept)
+  // identically everywhere, instead of depending on which path happened to reach it first -
+  // otherwise one allOf member can carry an intact copy of a property while another carries
+  // an over-cut permissive copy of the same property, and the faker satisfies only the cut.
+  const minDepth = new Map();
+  const queue = [[root, 0]];
+  while (queue.length) {
+    const [node, depth] = queue.shift();
+    if (node === null || typeof node !== "object") continue;
+    if (minDepth.has(node) && minDepth.get(node) <= depth) continue;
+    minDepth.set(node, depth);
+    if (Array.isArray(node)) {
+      for (const x of node) queue.push([x, depth]);
+      continue;
+    }
+    for (const [k, v] of Object.entries(node)) {
+      const step = INSTANCE_KEYWORDS.has(k) || k === "prefixItems" ? 1 : 0;
+      if (INSTANCE_MAP_KEYWORDS.has(k) && v && typeof v === "object" && !Array.isArray(v)) {
+        queue.push([v, depth]);
+        for (const pv of Object.values(v)) queue.push([pv, depth + 1]);
+      } else {
+        queue.push([v, depth + step]);
+      }
+    }
+  }
+  // Pass 2: copy, cutting cycles (path-local) and nodes whose best depth exceeds the budget.
   const memo = new Map();
-  const walk = (node, path, depth) => {
+  const walk = (node, path) => {
     if (node === null || typeof node !== "object") return node;
-    if (path.has(node)) return {};        // cycle: node references itself or an ancestor
+    if (path.has(node)) return cut();      // cycle: node references itself or an ancestor
     if (memo.has(node)) return memo.get(node); // shared node already bounded: reuse (keep DAG)
-    if (depth > maxDepth) return {};
+    if ((minDepth.get(node) ?? 0) > maxDepth) return cut();
     path.add(node);
     const out = Array.isArray(node) ? [] : {};
     memo.set(node, out);
-    if (Array.isArray(node)) node.forEach((x, i) => (out[i] = walk(x, path, depth + 1)));
+    if (Array.isArray(node)) node.forEach((x, i) => (out[i] = walk(x, path)));
     else for (const [k, v] of Object.entries(node)) {
       // Drop identity keys: dereferencing inlines a $ref'd leaf under many properties, each
       // keeping its $id, which makes ajv see one $id resolving to several schemas.
       if (k === "$id" || k === "$schema") continue;
-      out[k] = walk(v, path, depth + 1);
+      out[k] = walk(v, path);
     }
     path.delete(node);
     return out;
   };
-  return walk(root, new Set(), 0);
+  return walk(root, new Set());
 }
 
 async function dereffed(schemaFile) {
@@ -210,7 +256,12 @@ function canonical(v) {
 // broken) @context term drops out of RDF, so its key disappears from the reconstruction,
 // while value coercion (e.g. a reference string resolving to an absolute IRI) keeps the
 // key and so is not falsely reported.
+// A JSON-LD no-op value: null, [], or an array of nothing but no-ops ([null], [[]], ...).
+// Such a value produces no triples, so its key legitimately disappears on the way back.
+const isNoop = (v) => v === null || (Array.isArray(v) && v.every(isNoop));
+
 function lostKeys(before, after, path = "", lost = []) {
+  if (isNoop(before)) return lost;
   if (Array.isArray(before)) {
     const arr = Array.isArray(after) ? after : after == null ? [] : [after];
     for (const el of before) {
@@ -224,6 +275,7 @@ function lostKeys(before, after, path = "", lost = []) {
       : Array.isArray(after) ? after.find((x) => x && typeof x === "object") || {} : {};
     for (const k of Object.keys(before)) {
       if (k === "@context" || k === "$schema") continue;
+      if (isNoop(before[k])) continue;
       const p = path ? `${path}.${k}` : k;
       if (!(k in a)) lost.push(p);
       else lostKeys(before[k], a[k], p, lost);
@@ -343,6 +395,22 @@ for (const f of instanceFiles) {
   } catch (e) { bad(`ERROR      ${f}: ${e.message}`); }
 }
 
+// The faker draws URLs from a small pool, so two generated `id` values in one document can
+// collide. In RDF the same IRI is the same node: a colliding embed merges into its parent
+// and the round-trip then faithfully reports the merged graph - a false schema failure. Give
+// every generated node a unique id instead (only where the faker already put one).
+let nextId = 0;
+function uniquifyIds(v) {
+  if (Array.isArray(v)) v.forEach(uniquifyIds);
+  else if (v && typeof v === "object") {
+    // A distinct authority (not the document BASE host), or compaction would relativize
+    // the id against the base and break strict `format: iri` schemas.
+    if (typeof v.id === "string") v.id = `https://instances.example.org/id/${nextId++}`;
+    for (const x of Object.values(v)) uniquifyIds(x);
+  }
+  return v;
+}
+
 console.log("\nAuto-generated instances (satisfiability, formats respected):");
 const genSamples = {};
 for (const f of schemaFiles) {
@@ -350,6 +418,7 @@ for (const f of schemaFiles) {
     const schema = await dereffed(f);
     let sample = jsfGen.generate(schema);
     if (sample && typeof sample.then === "function") sample = await sample;
+    uniquifyIds(sample);
     genSamples[f] = sample;
     const validate = compileValidator(schema);
     if (validate(sample)) ok(`${f}`);
@@ -435,6 +504,7 @@ for (const f of schemaFiles) {
     try {
       let sample = jsfGen.generate(v.schema);
       if (sample && typeof sample.then === "function") sample = await sample;
+      uniquifyIds(sample);
       if (!validate(sample)) { bad(`VARIANT    ${f} ${v.label}: generated instance rejected: ` + JSON.stringify(validate.errors)); continue; }
       const { lost, restored } = await roundtrip(schema, sample, BASE + f);
       if (lost.length) bad(`VARIANT-RT ${f} ${v.label}: propert${lost.length > 1 ? "ies" : "y"} lost through RDF: ${lost.join(", ")}`);


### PR DESCRIPTION
Hardens the validation pipeline (#91) so it holds up against real-world schema sets (schema.org via OO-LD/schemaorg-parsing#2). With this PR `oold-validate` passes the generated schema.org set with nothing skipped (1333/1333), and the self-suite is 137/137. The datatype-coercion pattern rule originally bundled here now has its own PR, #104.

## Framing / embed detection

- `embeddedProperties` detects embeds from the JSON Schema shape (an object with `properties`, also behind `items`/`anyOf`/`oneOf`/`allOf`), since a scoped `@context` is not mandatory for an embed. A bare `$ref` is not treated as an embed (it may resolve to a scalar DataType leaf).
- Properties are collected through `allOf`, so dereferenced subclass chains (e.g. schema.org `Intangible`, whose properties all come from `Thing`) get frames for their inherited embeds instead of a flattened `@graph`.

## Bounded schema (faker/ajv input)

- Depth now counts instance nesting, not raw JSON nesting: an `allOf` hop nests no instance level, so subclass chains no longer burn the depth budget and lose their inherited property constraints (which made the faker emit junk that produced false RT-LOSSY/RT-ERROR reports).
- Cut decisions use each node's minimum reachable instance depth (0-1 BFS) so a shared node is treated identically on every path; previously one `allOf` member could carry an intact copy of a property while another carried an over-cut permissive copy.

## Generator determinism at cut nodes

- A cut node is `{"format": "x-oold-cut"}` rather than `{}`: ajv ignores the unknown format and, with no `type`, accepts any value (the permissiveness a shared cut node needs), while json-schema-faker treats a `format` node as a string.
- json-schema-faker picks a random type for a typeless node, so at a permissive cut it emitted booleans/numbers as often as strings; a non-string under an `@type: "@id"` term becomes an RDF literal that cannot compact back under that term, a false round-trip loss. The generator's `formats` option renders `x-oold-cut` as a unique marker string (and supplies `duration`/`date`/`time`, which this faker version has no built-in generator for). Faker is pinned to 0.6.2 for this behavior.

## Round-trip compare

- `null`, `[]`, `[null]`, ... are JSON-LD no-op values (they produce no triples), so a key holding one legitimately disappears on the way back; no longer counted as loss.
- Generated instances get unique `id`s: the faker's URL pool is small, and colliding ids merge RDF nodes (same IRI = same node), which the round-trip then faithfully reports as a false schema failure.