### PR TITLE
Drop index.html from the spec nav and remaining doc links

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,6 +1,6 @@
 # Guide
 
-This guide is a non-normative walk-through of OO-LD Schema. It follows the same orientation as the [JSON-LD specification](https://www.w3.org/TR/json-ld/): each concept is introduced with a short explanation and worked examples. For the exact, normative rules - and the RFC 2119 keywords - always refer to the [Specification](../spec/index.html).
+This guide is a non-normative walk-through of OO-LD Schema. It follows the same orientation as the [JSON-LD specification](https://www.w3.org/TR/json-ld/): each concept is introduced with a short explanation and worked examples. For the exact, normative rules - and the RFC 2119 keywords - always refer to the [Specification](../spec/).
 
 ## Contents
 

--- a/docs/migration/from-legacy-osw.md
+++ b/docs/migration/from-legacy-osw.md
@@ -216,7 +216,7 @@ different contexts.
 }
 ```
 
-See the [UI annotations section of the spec](../spec/index.html#ui-generation) for the
+See the [UI annotations section of the spec](../spec/#ui-generation) for the
 normative `x-oold-ui-*` definitions and the overlay format.
 
 ## Common pitfalls

--- a/zensical.toml
+++ b/zensical.toml
@@ -36,7 +36,7 @@ nav = [
         { "From legacy OSW" = "migration/from-legacy-osw.md" },
         { "Legacy keyword inventory" = "migration/legacy-keyword-inventory.md" },
     ]},
-    { "Specification" = "spec/index.html" },
+    { "Specification" = "spec/" },
 ]
 
 [project.theme]


### PR DESCRIPTION
The deployed Specification URL still carried `index.html` (e.g. `https://oo-ld.org/latest/spec/index.html`) instead of the clean directory URL `https://oo-ld.org/latest/spec/`.

Cause: the site nav pointed at the raw rendered file (`spec/index.html` in `zensical.toml`), and two doc links (`docs/guide/index.md`, `docs/migration/from-legacy-osw.md`) still used `../spec/index.html`. #101 dropped `index.html` from the other spec links but missed these three.

Fix: point the nav at `spec/` and the two links at `../spec/` (matching the pattern used everywhere else, e.g. the home hero and `../spec/#anchor` cross-links). Verified with `zensical build`: the spec page still outputs at `site/spec/index.html`, the nav renders `href="spec/"`, and no `spec/index.html` links remain in the built site.