### PR TITLE
Pin docs/rules.md to LF in the working tree

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,11 @@ meta/*.json  text eol=lf
 # Same reasoning for the compliance fixtures: they are copied verbatim into downstream test
 # suites, which compare them against upstream.
 examples/compliance/*.json  text eol=lf
+
+# A different reason: `render_rules_page.py` writes this file with an explicit `newline="\n"`, so
+# without the pin a Windows checkout is CRLF while every regeneration rewrites it as LF. The file
+# then sits permanently modified in `git status` with an empty `git diff`, since the diff
+# normalizes what the status stat-check does not. Phantom-dirty artifacts are worth avoiding here
+# in particular, because a clean tree after regeneration is exactly the signal the drift guard
+# relies on.
+docs/rules.md  text eol=lf


### PR DESCRIPTION
Follow-up to #123, one line of `.gitattributes`.

`render_rules_page.py` writes `docs/rules.md` with an explicit `newline="\n"`, but unlike `meta/*.json` and `examples/compliance/*.json` it was never pinned in `.gitattributes`. With `core.autocrlf=true` the checkout is CRLF, every regeneration rewrites it as LF, and the file then sits permanently ` M` in `git status` with an **empty `git diff`** (diff normalizes line endings, the status stat-check does not).

Harmless in substance, but it costs the drift guard its signal: "clean tree after regenerating" is what that check means, and an always-dirty artifact trains you to ignore it.

Verified on Windows with `autocrlf=true`: `git status` after `make check` goes from ` M docs/rules.md` to clean. `make check` passes end to end, 149/149 and the known coverage warning, no drift.

**Not included:** `docs/spec/index.html` is in a similar position but works by accident, since `render_spec.py` uses the platform-default newline, which happens to match `autocrlf=true` on Windows and LF on Linux. It breaks under `autocrlf=false`. Fixing it properly means pinning it *and* changing `render_spec.py`, which touches the artifact CI diffs byte-for-byte, so it deserves its own PR.
