### PR TITLE
Deep-link the Minimal example into the playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ OO-LD connects the structural modelling of objects and subobjects with the model
 }
 ```
 
-The JSON Schema part (`type`, `properties`) describes the structure; the `@context` maps `name` to the semantic term `schema:name`. Try it in the [interactive playground](https://oo-ld.github.io/playground/).
+The JSON Schema part (`type`, `properties`) describes the structure; the `@context` maps `name` to the semantic term `schema:name`. Try it in the [interactive playground](https://oo-ld.github.io/playground/?schema=https://oo-ld.org/latest/schemas/Minimal.schema.json).
 
 ## Documentation
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -17,7 +17,7 @@ The core idea of OO-LD is that a single document is at once a valid **JSON Schem
 
 ## Step 2 - Try it in the playground
 
-You can explore this exact example - validation, UI generation, and RDF output - in the [interactive playground](https://oo-ld.github.io/playground/).
+You can explore this exact example - validation, UI generation, and RDF output - in the [interactive playground](https://oo-ld.github.io/playground/?schema=https://oo-ld.org/latest/schemas/Minimal.schema.json). The playground otherwise opens with the richer `Person` example; every official example under [`examples/`](https://github.com/OO-LD/oold-schema/tree/main/examples) can be loaded the same way via `?schema=`.
 
 ## Step 3 - Validate schemas in this repository
 

--- a/docs/guide/basic-concepts.md
+++ b/docs/guide/basic-concepts.md
@@ -6,7 +6,7 @@ A minimal example:
 
 {{ example('Minimal') }}
 
-You can explore this in the [interactive playground](https://oo-ld.github.io/playground/).
+You can explore this exact example in the [interactive playground](https://oo-ld.github.io/playground/?schema=https://oo-ld.org/latest/schemas/Minimal.schema.json).
 
 ## Schemas vs. instances
 


### PR DESCRIPTION
The playgrounds now open with the official `Person` example loaded from the deployment, so the docs' "explore this exact example" wording (which referred to the `Minimal` schema shown just above) no longer matched what the playground actually displayed.

This points the three playground links (`docs/get-started.md`, `docs/guide/basic-concepts.md`, `README.md`) at the new `?schema=` query param, loading the canonical `Minimal` schema:

`https://oo-ld.github.io/playground/?schema=https://oo-ld.org/latest/schemas/Minimal.schema.json`

So the exact example the reader just saw is what opens in the playground. Get Started also gains a one-line note that the playground otherwise opens with the richer `Person` example and that any official example can be loaded the same way.

Only the three markdown files change; the generated `docs/spec/index.html` is untouched. The deep-link URL and the `?schema=` support are already live (verified 200).