### PR TITLE
Stop the rule catalogue recording an inverted level

### DIFF
--- a/scripts/extract_rules.py
+++ b/scripts/extract_rules.py
@@ -48,7 +48,13 @@ APPLIES = ("document", "implementation", "advisory")
 
 HEADING = re.compile(r"^\s*#{2,6}\s+.*\{[^}]*#([A-Za-z0-9_-]+)[^}]*\}\s*$")
 ATTR = re.compile(r'(\w+)\s*=\s*(?:"([^"]*)"|(\S+))')
-RFC2119 = re.compile(r"\b(MUST NOT|MUST|SHALL NOT|SHALL|SHOULD NOT|SHOULD|REQUIRED|RECOMMENDED)\b")
+#: Every negated form is listed before the bare keyword it contains, so the alternation matches the
+#: longer one. `NOT RECOMMENDED` is an RFC 2119 keyword ([RFC2119] §4) like the `X NOT` forms, but
+#: negates on the left, so without its own branch the bare `RECOMMENDED` inside it would match and a
+#: prohibition would be catalogued as a recommendation.
+RFC2119 = re.compile(
+    r"\b(MUST NOT|MUST|SHALL NOT|SHALL|SHOULD NOT|SHOULD|NOT RECOMMENDED|REQUIRED|RECOMMENDED)\b"
+)
 
 LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.)\s")
 
@@ -400,7 +406,12 @@ def extract_file(filename: str, problems: list[str], notes: list[str]) -> list[d
                     continue
             else:
                 level = RFC2119.search(text).group(1)
-            if level not in context:
+            # Membership in the keywords the prose actually matched, not a substring test: `MUST` is
+            # a substring of `MUST NOT`, so `in context` accepts `level=MUST` on a prohibition and
+            # files the rule as the opposite of what it says. Same for SHALL, SHOULD and
+            # RECOMMENDED against their negated forms. The catalogue is cited for the authority of
+            # its level, so an inverted one is worse than a missing rule.
+            if level not in {match.group(1) for match in RFC2119.finditer(context)}:
                 problems.append(f"{where}: {rule_id} declares level={level!r}, absent from the marked prose")
                 continue
 


### PR DESCRIPTION
Two ways `scripts/extract_rules.py` could file a rule's `level` as the opposite of what its prose says. Both silent; neither fires on the spec as it stands. Found reviewing https://github.com/OO-LD/oold-schema/pull/123.

## Changes

- `RFC2119`: add a `NOT RECOMMENDED` branch, ordered before the bare `RECOMMENDED`, as the `X NOT` forms already are.
- Authored `level=`: validate against the keywords the marked prose actually matched, instead of `if level not in context`.

## Rationale

**`NOT RECOMMENDED` extracted as `RECOMMENDED`.** It is an RFC 2119 keyword ([RFC 2119 section 4](https://www.rfc-editor.org/rfc/rfc2119#section-4)) but negates on the left, so without its own branch the bare keyword inside it matched:

```
'Use of x is NOT RECOMMENDED.' -> RECOMMENDED
```

No section uses the term yet, and nothing would have warned.

**`level not in context` is a substring test.** `"MUST" in "MUST NOT"` is true, so `level=MUST` on a prohibition passed. Once accepted, the baseline guard holds the inversion in place as reviewed text. Same for `SHOULD` and `SHALL` against their negated forms.

An inverted level is worse than a missing rule: downstream cites the id for the authority of the level.

## Verification

Changing only the attribute on a real marker (`OOLD-SCH-a9ee`, whose sentence says MUST NOT):

| | before | after |
|---|---|---|
| `level="MUST"` | recorded `level: MUST` | exit 1, `declares level='MUST', absent from the marked prose` |
| unmodified prose | exit 0 | exit 0 |

`make check` 149/149 with the known fixture-coverage warning, `rule baseline OK (43 rules)`, catalogue unchanged, no drift.