### PR TITLE
Point latest at the most recent release until v1.0.0 ships

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,14 +108,15 @@ jobs:
           # --alias-type=copy so /latest/ is a real directory (its schema JSON is
           # fetchable; a redirect alias would 404 for machine schema references).
           MIKE="uvx --with pyyaml==6.0.2 --from $MIKE_SPEC mike"
-          case "$ver" in
-            *-*)
-              # Pre-release (semver has a hyphen, e.g. 1.0.0-rc.1): publish the versioned
-              # docs only. Do NOT move `latest` or the site default - those track the most
-              # recent STABLE release, so /latest/ never serves a release candidate.
-              $MIKE deploy --push "$ver" ;;
-            *)
-              # Stable release: publish and repoint `latest` + the site default.
-              $MIKE deploy --push --alias-type=copy --update-aliases "$ver" latest
-              $MIKE set-default --push latest ;;
-          esac
+          # TEMPORARY, until v1.0.0 ships: every release, pre-release included, repoints
+          # `latest` and the site default. During the v1.0 review window the candidate is the
+          # document reviewers should be reading, and a /latest/ still serving 0.9.0 sends
+          # them to superseded prose. The concrete /X.Y.Z/ of every release stays published,
+          # so pinning remains possible.
+          #
+          # REVERT WHEN v1.0.0 IS TAGGED: restore the `case "$ver" in *-*) ... esac` guard so
+          # that `latest` tracks the most recent STABLE release again and never serves a
+          # release candidate. After v1.0 the trade-off flips - a stable spec exists, and
+          # /latest/ pointing at a candidate would then be the misleading answer.
+          $MIKE deploy --push --alias-type=copy --update-aliases "$ver" latest
+          $MIKE set-default --push latest


### PR DESCRIPTION
## Problem

The deploy job keeps `latest` and the site default on the most recent *stable* release, so with v1.0.0-rc.2 published, https://oo-ld.org/latest/ still serves **0.9.0**.

Two concrete symptoms:

- https://oo-ld.org/latest/spec/ serves 0.9.0 prose, not the candidate that https://github.com/OO-LD/oold-schema/issues/116 asks people to review.
- https://oo-ld.org/latest/rules/ returns **404**, because the rule catalogue page does not exist in 0.9.0.

## Change

`latest` and the site default follow every release, pre-releases included. The `case` on the semver hyphen is dropped.

**This is temporary.** The comment in the workflow says so and names the revert: when v1.0.0 is tagged, restore the guard so `latest` tracks stable releases again. After v1.0 the trade-off flips, since a stable spec exists and pointing `latest` at a candidate would then be the misleading answer.

Every concrete `/X.Y.Z/` stays published, so pinning a specific version is unaffected.

## Applying it to rc.2

The tag workflow reads its definition from the tagged commit, so v1.0.0-rc.2 has to be moved onto this change for the deploy to re-run with it. I will move the tag and force-push it after merge; the published release and its notes are unaffected, and the spec artifacts do not change since `spec_version` is already stamped rc.2.