### PR TITLE
fix(spec): admit NOT RECOMMENDED as a rule level

### DIFF
--- a/meta/oold-rules.schema.json
+++ b/meta/oold-rules.schema.json
@@ -109,7 +109,8 @@
             "SHOULD",
             "SHOULD NOT",
             "REQUIRED",
-            "RECOMMENDED"
+            "RECOMMENDED",
+            "NOT RECOMMENDED"
           ],
           "description": "The RFC 2119 keyword in the marked prose. A validator reads this to decide whether a violation fails or warns, and never hardcodes it."
         },

--- a/scripts/check_spec.py
+++ b/scripts/check_spec.py
@@ -92,6 +92,32 @@ if os.path.exists(RULES_FILE):
     with open(RULES_FILE, encoding="utf-8") as handle:
         rules = json.load(handle).get("rules", [])
 
+# The keywords extraction recognises and the levels the catalog schema admits are two lists of
+# the same thing, written in two files. When they drift, the failure lands nowhere near the
+# cause: extraction succeeds, and the catalog it wrote then fails its own schema. That is what
+# happened when NOT RECOMMENDED was added to the extractor alone.
+RULES_SCHEMA_FILE = os.path.join(ROOT, "meta", "oold-rules.schema.json")
+if os.path.exists(RULES_SCHEMA_FILE):
+    sys.path.insert(0, HERE)
+    from extract_rules import RFC2119  # noqa: E402
+
+    with open(RULES_SCHEMA_FILE, encoding="utf-8") as handle:
+        allowed = json.load(handle)["$defs"]["rule"]["properties"]["level"]["enum"]
+    recognised = RFC2119.pattern.split("(", 1)[1].split(")", 1)[0].split("|")
+    for keyword in recognised:
+        if keyword not in allowed:
+            errors.append(
+                f"extraction recognises the level {keyword!r} but meta/oold-rules.schema.json "
+                "does not admit it, so a rule stated with it would write a catalog that fails "
+                "its own schema. Add it to the level enum."
+            )
+    for keyword in allowed:
+        if keyword not in recognised:
+            errors.append(
+                f"meta/oold-rules.schema.json admits the level {keyword!r} but extraction never "
+                "produces it. Remove it from the enum, or add it to RFC2119 in extract_rules.py."
+            )
+
 #: The anchor has to sit on the marked sentence itself - a <span class="rule" id="...">
 #: emitted by render_spec.py - so that following a cited link lands on the requirement and
 #: `:target` can highlight it. class="rule" and id="..." can appear in either order on the

--- a/scripts/check_spec.py
+++ b/scripts/check_spec.py
@@ -98,12 +98,10 @@ if os.path.exists(RULES_FILE):
 # happened when NOT RECOMMENDED was added to the extractor alone.
 RULES_SCHEMA_FILE = os.path.join(ROOT, "meta", "oold-rules.schema.json")
 if os.path.exists(RULES_SCHEMA_FILE):
-    sys.path.insert(0, HERE)
-    from extract_rules import RFC2119  # noqa: E402
+    from extract_rules import RFC2119_LEVELS as recognised  # noqa: E402
 
     with open(RULES_SCHEMA_FILE, encoding="utf-8") as handle:
         allowed = json.load(handle)["$defs"]["rule"]["properties"]["level"]["enum"]
-    recognised = RFC2119.pattern.split("(", 1)[1].split(")", 1)[0].split("|")
     for keyword in recognised:
         if keyword not in allowed:
             errors.append(

--- a/scripts/extract_rules.py
+++ b/scripts/extract_rules.py
@@ -48,13 +48,28 @@ APPLIES = ("document", "implementation", "advisory")
 
 HEADING = re.compile(r"^\s*#{2,6}\s+.*\{[^}]*#([A-Za-z0-9_-]+)[^}]*\}\s*$")
 ATTR = re.compile(r'(\w+)\s*=\s*(?:"([^"]*)"|(\S+))')
-#: Every negated form is listed before the bare keyword it contains, so the alternation matches the
-#: longer one. `NOT RECOMMENDED` is an RFC 2119 keyword ([RFC2119] §4) like the `X NOT` forms, but
-#: negates on the left, so without its own branch the bare `RECOMMENDED` inside it would match and a
-#: prohibition would be catalogued as a recommendation.
-RFC2119 = re.compile(
-    r"\b(MUST NOT|MUST|SHALL NOT|SHALL|SHOULD NOT|SHOULD|NOT RECOMMENDED|REQUIRED|RECOMMENDED)\b"
+#: The levels a rule can be stated with, in match order: every negated form precedes the bare
+#: keyword it contains, so the alternation takes the longer one. `NOT RECOMMENDED` is an RFC 2119
+#: keyword ([RFC2119] §4) like the `X NOT` forms, but negates on the left, so without its own entry
+#: the bare `RECOMMENDED` inside it would match and a prohibition would be catalogued as a
+#: recommendation.
+#:
+#: `meta/oold-rules.schema.json` constrains `level` to this same vocabulary, and `check_spec.py`
+#: compares the two. Declared as a list rather than written straight into the pattern so that the
+#: comparison reads the vocabulary itself, not a substring of a regex.
+RFC2119_LEVELS = (
+    "MUST NOT",
+    "MUST",
+    "SHALL NOT",
+    "SHALL",
+    "SHOULD NOT",
+    "SHOULD",
+    "NOT RECOMMENDED",
+    "REQUIRED",
+    "RECOMMENDED",
 )
+
+RFC2119 = re.compile(r"\b(" + "|".join(RFC2119_LEVELS) + r")\b")
 
 LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.)\s")
 


### PR DESCRIPTION
`meta/oold-rules.schema.json` constrains `level` to 8 values. https://github.com/OO-LD/oold-schema/pull/128 added `NOT RECOMMENDED` to the extractor's `RFC2119` alternation but not to that enum, so a rule stated with it extracts cleanly and then fails the catalogue's own schema:

```
INVALID oold-rules.json: [{"instancePath":"/rules/12/level","schemaPath":"#/properties/level/enum",
  "keyword":"enum","params":{"allowedValues":["MUST","MUST NOT","SHALL","SHALL NOT","SHOULD",
  "SHOULD NOT","REQUIRED","RECOMMENDED"]},"message":"must be equal to one of the allowed values"}]
```

No rule uses the keyword yet, so nothing is broken today.

## Changes

- `meta/oold-rules.schema.json`: add `NOT RECOMMENDED` to the `level` enum.
- `scripts/check_spec.py`: fail when the extractor's recognised keywords and the schema's enum disagree in either direction.

The guard is the point. The two lists describe the same vocabulary in two files, and when they drift the failure surfaces nowhere near the cause: extraction succeeds, and the catalogue it just wrote fails validation.

Verified by re-running the probe that produced the error above: `OK oold-rules.json (67 rules)` after the change, and `spec check FAILED` naming the keyword when the enum entry is removed again.

`make check` 149/149, `rule baseline OK (66 rules)`, no drift.